### PR TITLE
feat: [NMP-124] Soil Tests Tab

### DIFF
--- a/frontend/src/views/FarmInformation/FarmInformation.tsx
+++ b/frontend/src/views/FarmInformation/FarmInformation.tsx
@@ -57,7 +57,7 @@ export default function FarmInformation() {
 
     if (state.nmpFile) nmpFile = JSON.parse(state.nmpFile);
     else nmpFile = defaultNMPFile;
-
+    console.log('nmpFile', nmpFile);
     nmpFile.farmDetails = { ...nmpFile.farmDetails, ...formData };
 
     setNMPFile(JSON.stringify(nmpFile));

--- a/frontend/src/views/FarmInformation/FarmInformation.tsx
+++ b/frontend/src/views/FarmInformation/FarmInformation.tsx
@@ -57,7 +57,7 @@ export default function FarmInformation() {
 
     if (state.nmpFile) nmpFile = JSON.parse(state.nmpFile);
     else nmpFile = defaultNMPFile;
-    console.log('nmpFile', nmpFile);
+
     nmpFile.farmDetails = { ...nmpFile.farmDetails, ...formData };
 
     setNMPFile(JSON.stringify(nmpFile));

--- a/frontend/src/views/FieldAndSoil/FieldAndSoil.tsx
+++ b/frontend/src/views/FieldAndSoil/FieldAndSoil.tsx
@@ -7,6 +7,7 @@ import useAppService from '@/services/app/useAppService';
 import NMPFile from '@/types/NMPFile';
 import defaultNMPFile from '@/constants/DefaultNMPFile';
 import FieldList from './FieldList/FieldList';
+import SoilTests from './SoilTests/SoilTests';
 import { Card, Button } from '../../components/common';
 import { TabOptions, TabContentDisplay } from '../../components/common/Tabs/Tabs';
 import { CardHeader, Banner, ButtonWrapper } from './fieldAndSoil.styles';
@@ -40,7 +41,17 @@ export default function FieldAndSoil() {
     {
       id: 'soil-test',
       label: 'Soil Tests',
-      content: <div>Soil Tests</div>,
+      content: (
+        <SoilTests
+          fields={fields}
+          setFields={setFields}
+        />
+      ),
+    },
+    {
+      id: 'crops',
+      label: 'Crops',
+      content: <div> </div>,
     },
   ];
 

--- a/frontend/src/views/FieldAndSoil/SoilTests/SoilTests.tsx
+++ b/frontend/src/views/FieldAndSoil/SoilTests/SoilTests.tsx
@@ -1,0 +1,166 @@
+/**
+ * @summary This is the Soil Tests Tab
+ */
+import { useState } from 'react';
+import { Dropdown, Modal, InputField } from '../../../components/common';
+import { InfoBox, ListItemContainer } from './soilTests.styles';
+
+interface FieldListProps {
+  fields: any[];
+  setFields: (fields: any[]) => void;
+}
+
+export default function SoilTests({ fields, setFields }: FieldListProps) {
+  const [soilTestData, setSoilTestData] = useState({
+    SoilTest: '1',
+    ConvertedKelownaK: '2',
+    ConvertedKelownaP: '4',
+    ValP: '',
+    sampleDate: '',
+    valK: '',
+    valNO3H: '',
+    valPH: '',
+  });
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const [currentFieldIndex, setCurrentFieldIndex] = useState<number | null>(null);
+
+  const soilTestOptions = [
+    { value: 1, label: 'No Soil Test from within the past 3 years' },
+    { value: 2, label: 'Other Lab (Bicarbonate and Amm Acetate)' },
+  ];
+
+  const handleChange = (e: { target: { name: any; value: any } }) => {
+    const { name, value } = e.target;
+    setSoilTestData({ ...soilTestData, [name]: value });
+  };
+
+  const handleEditSoilTest = (index: number) => {
+    setCurrentFieldIndex(index);
+    setSoilTestData(fields[index].SoilTest || {});
+    setIsModalVisible(true);
+  };
+
+  const handleDeleteSoilTest = (index: number) => {
+    const updatedFields = fields.map((field, i) =>
+      i === index ? { ...field, SoilTest: {} } : field,
+    );
+    setFields(updatedFields);
+  };
+
+  const handleSubmit = () => {
+    if (currentFieldIndex !== null) {
+      const updatedFields = fields.map((field, index) =>
+        index === currentFieldIndex ? { ...field, SoilTest: soilTestData } : field,
+      );
+      setFields(updatedFields);
+      setIsModalVisible(false);
+    }
+  };
+
+  return (
+    <div>
+      <InfoBox>
+        Do you have soil test from within the past 3 years?
+        <ul>
+          <li>Yes - Select the lab used (soil test methods)</li>
+          <li>No - Click Next</li>
+        </ul>
+      </InfoBox>
+      <Dropdown
+        label="Lab (Soil Test Method)"
+        name="SoilTest"
+        value={soilTestData.SoilTest}
+        options={soilTestOptions}
+        onChange={handleChange}
+      />
+      {soilTestData.SoilTest !== '1' && (
+        <div>
+          {fields.map((field, index) => (
+            <ListItemContainer key={field.FieldName}>
+              <p>Field Name: {field.FieldName}</p>
+              <p>Sampling Month: {field.SoilTest.sampleDate}</p>
+              <p>NO3-N (ppm): {field.SoilTest.valNO3H}</p>
+              <p>P (ppm): {field.SoilTest.ValP}</p>
+              <p>K (ppm): {field.SoilTest.valK}</p>
+              <p>pH: {field.SoilTest.valPH}</p>
+              {Object.keys(field.SoilTest).length === 0 ? (
+                <button
+                  type="button"
+                  onClick={() => handleEditSoilTest(index)}
+                >
+                  Add Soil Test Results
+                </button>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => handleEditSoilTest(index)}
+                  >
+                    Edit Soil Test
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDeleteSoilTest(index)}
+                  >
+                    Delete Soil Test
+                  </button>
+                </>
+              )}
+            </ListItemContainer>
+          ))}
+        </div>
+      )}
+      {isModalVisible && (
+        <Modal
+          isVisible={isModalVisible}
+          title="Edit Soil Test"
+          onClose={() => setIsModalVisible(false)}
+          footer={
+            <button
+              type="button"
+              onClick={handleSubmit}
+            >
+              Submit
+            </button>
+          }
+        >
+          <InputField
+            label="Sample Month"
+            type="month"
+            name="sampleDate"
+            value={soilTestData.sampleDate}
+            onChange={handleChange}
+          />
+          <InputField
+            label="NO3-N (ppm), nitrate-nitrogen"
+            type="text"
+            name="valNO3H"
+            value={soilTestData.valNO3H}
+            onChange={handleChange}
+          />
+          <InputField
+            label="P (ppm), phosphorus"
+            type="text"
+            name="ValP"
+            value={soilTestData.ValP}
+            onChange={handleChange}
+          />
+          <InputField
+            label="K (ppm), potassium"
+            type="text"
+            name="valK"
+            value={soilTestData.valK}
+            onChange={handleChange}
+          />
+          <InputField
+            label="pH"
+            type="text"
+            name="valPH"
+            value={soilTestData.valPH}
+            onChange={handleChange}
+          />
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/views/FieldAndSoil/SoilTests/soilTests.styles.ts
+++ b/frontend/src/views/FieldAndSoil/SoilTests/soilTests.styles.ts
@@ -1,0 +1,29 @@
+/**
+ * @summary Styling for FieldList view
+ */
+import styled from '@emotion/styled';
+
+export const ListItemContainer = styled.div`
+  display: flex;
+  gap: 16px;
+  margin-top: 16px;
+  width: 100%;
+  justify-content: flex-start;
+  align-items: center;
+`;
+
+export const InfoBox = styled.div`
+  background-color: rgba(200, 200, 200, 0.3);
+  padding: 10px;
+  border-radius: 5px;
+  margin-top: 10px;
+  justify-content: center;
+`;
+
+export const InfoBoxContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+`;


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [x] Documentation is updated to reflect change

# Description
The Soil Test tab is the second step in the Fields and Soil Sections. It collects past soil test results
This PR includes the following proposed change(s):

- SoilTests tab created
- Modal with required fields present as describe in the ticket
- form data saves to nmp form upon completion
- Empty Crops Tab added

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-nmp-129-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-nmp-129-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/merge.yml)