### PR TITLE
feat: [NR-NMP-219] Update field information page UI and field list table

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@mui/material": "^6.4.8",
+        "@mui/x-data-grid": "^7.28.3",
         "axios": "^1.8.4",
         "mathjs": "^14.2.1",
         "react": "^19.0.0",
@@ -1513,6 +1514,64 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@mui/x-data-grid": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-7.28.3.tgz",
+      "integrity": "sha512-T2Vd+3pAnI7UD3B1y+Z7e1eB9N7PCgPbn44KhxM3iT1ldT49HHQ7c2wDHm2Qf4F5UHL6dxvsBF3sGnGyfo+JOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+        "@mui/x-internals": "7.28.0",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-internals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.28.0.tgz",
+      "integrity": "sha512-p4GEp/09bLDumktdIMiw+OF4p+pJOOjTG0VUvzNxjbHB9GxbBKoMcHrmyrURqoBnQpWIeFnN/QAoLMFSpfwQbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7924,6 +7983,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@mui/material": "^6.4.8",
+    "@mui/x-data-grid": "^7.28.3",
     "axios": "^1.8.4",
     "mathjs": "^14.2.1",
     "react": "^19.0.0",

--- a/frontend/src/common.styles.ts
+++ b/frontend/src/common.styles.ts
@@ -7,6 +7,7 @@ export const componentContainer = css({
   marginLeft: '3rem',
   marginRight: '3rem',
   maxWidth: '900px',
+  width: '100%',
 });
 
 export const formCss = css({
@@ -65,7 +66,6 @@ export const paragraphCss = css({
 export const buttonGroup = css({
   '.bcds-ButtonGroup': {
     marginTop: '1rem',
-    marginBottom: '3rem',
   },
 });
 

--- a/frontend/src/components/common/TabsMaterial/TabsMaterial.tsx
+++ b/frontend/src/components/common/TabsMaterial/TabsMaterial.tsx
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react';
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
+import Box from '@mui/material/Box';
+
+export default function BasicTabs({
+  activeTab,
+  tabLabel,
+}: {
+  activeTab: number;
+  tabLabel: Array<string>;
+}) {
+  const [value, setValue] = useState(activeTab);
+
+  useEffect(() => setValue(activeTab), [activeTab, setValue]);
+
+  return (
+    <Box sx={{ width: '100%' }}>
+      <Box>
+        <Tabs
+          value={value}
+          aria-label="tab"
+        >
+          {tabLabel.map((ele) => (
+            <Tab
+              label={ele}
+              key={ele}
+            />
+          ))}
+        </Tabs>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -10,6 +10,7 @@ import Modal from './Modal/Modal';
 import ProgressStepper from './ProgressStepper/ProgressStepper';
 import AppTitle from './AppTitle/AppTitle';
 import PageTitle from './PageTitle/PageTitle';
+import TabsMaterial from './TabsMaterial/TabsMaterial';
 
 export {
   Header,
@@ -24,4 +25,5 @@ export {
   ProgressStepper,
   AppTitle,
   PageTitle,
+  TabsMaterial,
 };

--- a/frontend/src/views/FarmInformation/FarmInformation.tsx
+++ b/frontend/src/views/FarmInformation/FarmInformation.tsx
@@ -301,20 +301,21 @@ export default function FarmInformation() {
               }}
               orientation="horizontal"
             />
+            {/* <div>{JSON.stringify(formData)}</div> */}
             <div css={formData.HasHorticulturalCrops ? showCheckboxGroup : hideCheckboxGroup}>
               <Checkbox
                 value="HasVegetables"
-                isSelected={formData.HasVegetables || false}
+                isSelected={formData.HasVegetables}
                 onChange={(s) => handleChange('HasVegetables', s)}
               >
-                Vegetables
+                I have vegetables
               </Checkbox>
               <Checkbox
                 value="HasBerries"
-                isSelected={formData.HasBerries || false}
+                isSelected={formData.HasBerries}
                 onChange={(s) => handleChange('HasBerries', s)}
               >
-                Berries
+                I have berries
               </Checkbox>
             </div>
           </Grid>
@@ -356,19 +357,19 @@ export default function FarmInformation() {
         >
           <Button
             size="medium"
-            aria-label="Next"
-            variant="primary"
-            type="submit"
-          >
-            Next
-          </Button>
-          <Button
-            size="medium"
             aria-label="Back"
             onPress={() => navigate(LANDING_PAGE)}
             variant="secondary"
           >
             BACK
+          </Button>
+          <Button
+            size="medium"
+            aria-label="Next"
+            variant="primary"
+            type="submit"
+          >
+            Next
           </Button>
         </ButtonGroup>
       </Form>

--- a/frontend/src/views/FieldList/FieldList.tsx
+++ b/frontend/src/views/FieldList/FieldList.tsx
@@ -149,6 +149,9 @@ export default function FieldList() {
     }
   };
 
+  const isManureOptionValid = () =>
+    formData?.PreviousYearManureApplicationFrequency !== manureOptions[0].id;
+
   const columns: GridColDef[] = useMemo(
     () => [
       { field: 'FieldName', headerName: 'Field Type', width: 200, minWidth: 150, maxWidth: 300 },
@@ -278,10 +281,9 @@ export default function FieldList() {
                       onChange={(e) => handleFormFieldChange('Area', e?.trim())}
                     />
                   </Grid>
-
                   <Grid size={6}>
                     <span
-                      className={`bcds-react-aria-Select--Label ${isFormInvalid && !formData?.PreviousYearManureApplicationFrequency ? '--error' : ''}`}
+                      className={`bcds-react-aria-Select--Label ${isFormInvalid && !isManureOptionValid() ? '--error' : ''}`}
                     >
                       Manure Application
                     </span>
@@ -290,6 +292,7 @@ export default function FieldList() {
                       name="manureApplication"
                       items={manureOptions}
                       selectedKey={formData?.PreviousYearManureApplicationFrequency}
+                      validate={() => (!isManureOptionValid() ? 'required' : '')}
                       onSelectionChange={(e) => {
                         handleFormFieldChange(
                           'PreviousYearManureApplicationFrequency',

--- a/frontend/src/views/FieldList/FieldList.tsx
+++ b/frontend/src/views/FieldList/FieldList.tsx
@@ -1,29 +1,39 @@
 /**
  * @summary This is the Field list Tab
  */
-import React, { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import type { FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faEdit, faTrash } from '@fortawesome/free-solid-svg-icons';
-import { Dropdown, InputField, Button } from '../../components/common';
-import Modal from '@/components/common/Modal/Modal';
+import { faTrash, faEdit, faPlus } from '@fortawesome/free-solid-svg-icons';
 import {
-  ListItemContainer,
-  ButtonWrapper,
-  Header,
-  Column,
-  ListItem,
-  ContentWrapper,
-  ButtonContainer,
+  Button,
+  ButtonGroup,
+  Dialog,
+  Modal,
+  Form,
+  TextField,
+  Select,
+} from '@bcgov/design-system-react-components';
+import { DataGrid, GridColDef } from '@mui/x-data-grid';
+import Divider from '@mui/material/Divider';
+import Grid from '@mui/material/Grid2';
+import { AppTitle, PageTitle, ProgressStepper, TabsMaterial } from '../../components/common';
+import { formCss } from '../../common.styles';
+import {
+  customTableStyle,
+  StyledContent,
+  tableActionButtonCss,
   ErrorText,
 } from './fieldList.styles';
 import NMPFileFieldData from '@/types/NMPFileFieldData';
-import ViewCard from '@/components/common/ViewCard/ViewCard';
-import { FARM_INFORMATION, SOIL_TESTS } from '@/constants/RouteConstants';
+import { FARM_INFORMATION, FIELD_LIST, SOIL_TESTS } from '@/constants/RouteConstants';
 import { initFields, saveFieldsToFile } from '../../utils/utils';
 import useAppService from '@/services/app/useAppService';
 
-const initialFieldFormData = {
+type tempNMPFileFieldData = NMPFileFieldData & { id?: string };
+
+const initialFieldFormData: tempNMPFileFieldData = {
   FieldName: '',
   Area: '',
   PreviousYearManureApplicationFrequency: '0',
@@ -33,208 +43,335 @@ const initialFieldFormData = {
 };
 
 const manureOptions = [
-  { value: 0, label: 'Select' },
-  { value: 1, label: 'No Manure in the last 2 years' },
-  { value: 2, label: 'Manure applied in 1 of the 2 years' },
-  { value: 3, label: 'Manure applied in each of the 2 years' },
+  { id: '0', label: 'Select' },
+  { id: '1', label: 'No Manure in the last 2 years' },
+  { id: '2', label: 'Manure applied in 1 of the 2 years' },
+  { id: '3', label: 'Manure applied in each of the 2 years' },
 ];
 
 export default function FieldList() {
   const { state, setNMPFile, setProgressStep } = useAppService();
+  const [formData, setFormData] = useState<tempNMPFileFieldData>(initialFieldFormData);
+  const [isEditingForm, setIsEditingForm] = useState<boolean>(false);
+  const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
+  const [isFormInvalid, setIsFormInvalid] = useState<boolean>(false);
+  const [showViewError, setShowViewError] = useState<string>('');
+
   const navigate = useNavigate();
 
-  const [isModalVisible, setIsModalVisible] = useState(false);
-  const [editIndex, setEditIndex] = useState<number | null>(null);
-  const [fieldFormData, setFieldFormData] = useState<NMPFileFieldData>(initialFieldFormData);
-  const [fields, setFields] = useState<NMPFileFieldData[]>(initFields(state));
-  const [errors, setErrors] = useState<{ [key: string]: string }>({});
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
-    const { name, value } = e.target;
-    setFieldFormData({ ...fieldFormData, [name]: value });
-  };
-
-  const handleEdit = (index: number) => {
-    setFieldFormData(fields[index]);
-    setEditIndex(index);
-    setIsModalVisible(true);
-  };
-
-  const handleDelete = (index: number) => {
-    const updatedFields = fields.filter((_, i) => i !== index);
-    setFields(updatedFields);
-  };
-
-  const validate = () => {
-    const newErrors: { [key: string]: string } = {};
-    if (!fieldFormData.FieldName.trim()) {
-      newErrors.FieldName = 'Field Name is required';
-    } else if (
-      fields.some(
-        (field, index) =>
-          field.FieldName.trim().toLowerCase() === fieldFormData.FieldName.trim().toLowerCase() &&
-          index !== editIndex,
-      )
-    ) {
-      newErrors.FieldName = 'Field Name must be unique';
-    }
-    if (!fieldFormData.Area.trim() || Number.isNaN(Number(fieldFormData.Area))) {
-      newErrors.Area = 'Area is required and must be a number';
-    }
-    if (fieldFormData.PreviousYearManureApplicationFrequency === '0') {
-      newErrors.PreviousYearManureApplicationFrequency =
-        'Please select a manure application frequency';
-    }
-    return newErrors;
-  };
-
-  const handleSubmit = () => {
-    const validationErrors = validate();
-    if (Object.keys(validationErrors).length > 0) {
-      setErrors(validationErrors);
-      return;
-    }
-    setErrors({});
-    if (editIndex !== null) {
-      const updatedFields = fields.map((field, index) =>
-        index === editIndex ? fieldFormData : field,
-      );
-      setFields(updatedFields);
-      setEditIndex(null);
-    } else {
-      setFields([...fields, fieldFormData]);
-    }
-    setFieldFormData(initialFieldFormData);
-    setIsModalVisible(false);
-  };
-
-  const handleNext = () => {
-    saveFieldsToFile(fields, state.nmpFile, setNMPFile);
-    navigate(SOIL_TESTS);
-  };
-
-  const handlePrevious = () => {
-    navigate(FARM_INFORMATION);
-  };
+  const [fieldList, setFieldList] = useState<Array<tempNMPFileFieldData>>(
+    // Load NMP fields into view, add id key for UI tracking purposes
+    // id key removed on save
+    initFields(state).map((fieldElement: NMPFileFieldData, index: number) => ({
+      ...fieldElement,
+      id: index.toString(),
+    })),
+  );
 
   useEffect(() => {
     setProgressStep(3);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const filteredFields = fields.filter((field) => field.FieldName.trim() !== '');
+  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
+    // Prevent default browser page refresh.
+    e.preventDefault();
+
+    if (isEditingForm) {
+      // If editing, find and replace field instead of adding new field
+      const replaceIndex = fieldList.findIndex((element) => element?.id === formData?.id);
+      setFieldList((prev) => {
+        const newList = [...prev];
+        newList[replaceIndex] = { ...formData };
+        return newList;
+      });
+    } else {
+      //
+      setFieldList((prev) => [...prev, { ...formData, id: prev?.length.toString() ?? '0' }]);
+    }
+    setFormData(initialFieldFormData);
+    setIsEditingForm(false);
+    setIsDialogOpen(false);
+    setShowViewError('');
+  };
+
+  const handleFormFieldChange = (field: string, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const validateUniqueField = (): string => {
+    // Trigger validation error if blank, replaces default isRequired
+    if (!formData?.FieldName) return ' ';
+
+    // Check if field name is unique, with exception of editing the same field
+    const isNameValid = fieldList.some(
+      (fieldRow) => fieldRow.FieldName === formData.FieldName && fieldRow.id !== formData?.id,
+    );
+    return isNameValid ? ' must be unique' : '';
+  };
+
+  const handleEditRow = (e: any) => {
+    setIsEditingForm(true);
+    setFormData(e.row);
+    setIsDialogOpen(true);
+  };
+
+  const handleDeleteRow = (e: any) => {
+    console.log(e);
+    setFieldList((prev) => {
+      const newList = [...prev];
+      if (e?.id === 0 || e?.id) newList.splice(e.id, 1);
+      return newList;
+    });
+  };
+
+  const handleDialogClose = () => {
+    setIsDialogOpen(false);
+    setIsEditingForm(false);
+    setIsFormInvalid(false);
+    setFormData(initialFieldFormData);
+  };
+
+  const handleNextPage = () => {
+    setShowViewError('');
+
+    if (fieldList.length) {
+      saveFieldsToFile(
+        // Delete the id key in each field to prevent saving into NMPfile
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        fieldList.map(({ id, ...remainingFields }) => remainingFields),
+        state.nmpFile,
+        setNMPFile,
+      );
+      navigate(SOIL_TESTS);
+    } else {
+      setShowViewError('Must enter at least 1 field');
+    }
+  };
+
+  const columns: GridColDef[] = useMemo(
+    () => [
+      { field: 'FieldName', headerName: 'Field Type', width: 200, minWidth: 150, maxWidth: 300 },
+      { field: 'Area', headerName: 'Area', width: 150, minWidth: 125, maxWidth: 300 },
+      { field: 'Comment', headerName: 'Comment (optional)', minWidth: 200, maxWidth: 300 },
+      {
+        field: '',
+        headerName: 'Actions',
+        width: 120,
+        renderCell: (row: any) => (
+          <>
+            <FontAwesomeIcon
+              css={tableActionButtonCss}
+              onClick={() => handleEditRow(row)}
+              icon={faEdit}
+            />
+            <FontAwesomeIcon
+              css={tableActionButtonCss}
+              onClick={() => handleDeleteRow(row)}
+              icon={faTrash}
+            />
+          </>
+        ),
+        sortable: false,
+        resizable: false,
+      },
+    ],
+    [],
+  );
 
   return (
-    <ViewCard
-      heading="Field List"
-      handlePrevious={handlePrevious}
-      handleNext={handleNext}
-      nextDisabled={fields.length === 0}
-    >
-      <ButtonContainer hasFields={filteredFields.length > 0}>
-        <Button
-          text="Add Field"
-          handleClick={() => setIsModalVisible(true)}
-          aria-label="Add Field"
-          variant="primary"
-          size="sm"
-          disabled={false}
-        />
-      </ButtonContainer>
-      <ContentWrapper hasFields={filteredFields.length > 0}>
-        {filteredFields.length > 0 && (
-          <Header>
-            <Column>Field Name</Column>
-            <Column>Area</Column>
-            <Column>Comments</Column>
-            <Column align="right">Actions</Column>
-          </Header>
-        )}
-        {filteredFields.map((field, index) => (
-          <ListItemContainer key={field.FieldName}>
-            <ListItem>{field.FieldName}</ListItem>
-            <ListItem>{field.Area}</ListItem>
-            <ListItem>{field.Comment}</ListItem>
-            <ListItem align="right">
-              <button
-                type="button"
-                onClick={() => handleEdit(index)}
+    <StyledContent>
+      <ProgressStepper step={FIELD_LIST} />
+      <AppTitle />
+      <PageTitle title="Field Information" />
+      <>
+        <div
+          css={{
+            '.bcds-ButtonGroup': {
+              overflow: 'visible',
+              height: '0rem',
+              '> button': {
+                position: 'relative',
+                bottom: '-0.25rem',
+                zIndex: '10',
+              },
+            },
+          }}
+        >
+          <ButtonGroup
+            alignment="end"
+            ariaLabel="A group of buttons"
+            orientation="horizontal"
+          >
+            <Button
+              size="medium"
+              aria-label="Add Field"
+              onPress={() => setIsDialogOpen(true)}
+              variant="secondary"
+            >
+              <FontAwesomeIcon icon={faPlus} />
+              Add Field
+            </Button>
+          </ButtonGroup>
+        </div>
+        <Modal
+          isDismissable
+          isOpen={isDialogOpen}
+          onOpenChange={handleDialogClose}
+        >
+          <Dialog
+            isCloseable
+            role="dialog"
+          >
+            <div
+              style={{
+                padding: '1rem',
+              }}
+            >
+              <span
+                style={{
+                  fontWeight: '700',
+                  fontSize: '1.25rem',
+                }}
               >
-                <FontAwesomeIcon icon={faEdit} />
-              </button>
-              <button
-                type="button"
-                onClick={() => handleDelete(index)}
+                {isEditingForm ? 'Edit Field' : 'Add Field'}
+              </span>
+              <Divider
+                aria-hidden="true"
+                component="div"
+                css={{ marginTop: '0.5rem', marginBottom: '0.5rem' }}
+              />
+              <Form
+                css={formCss}
+                onSubmit={onSubmit}
+                onInvalid={() => setIsFormInvalid(true)}
               >
-                <FontAwesomeIcon icon={faTrash} />
-              </button>
-            </ListItem>
-          </ListItemContainer>
-        ))}
-      </ContentWrapper>
-      <Modal
-        isVisible={isModalVisible}
-        title={editIndex !== null ? 'Edit Field' : 'Add Field'}
-        onClose={() => setIsModalVisible(false)}
-        footer={
-          <>
-            <ButtonWrapper>
-              <Button
-                text="Cancel"
-                handleClick={() => setIsModalVisible(false)}
-                aria-label="Cancel"
-                variant="secondary"
-                size="sm"
-                disabled={false}
-              />
-            </ButtonWrapper>
-            <ButtonWrapper>
-              <Button
-                text="Submit"
-                handleClick={handleSubmit}
-                aria-label="Submit"
-                variant="primary"
-                size="sm"
-                disabled={false}
-              />
-            </ButtonWrapper>
-          </>
-        }
+                <Grid
+                  container
+                  spacing={1}
+                >
+                  <Grid size={6}>
+                    <span
+                      className={`bcds-react-aria-Select--Label ${isFormInvalid && validateUniqueField() ? '--error' : ''}`}
+                    >
+                      Field name {isFormInvalid && validateUniqueField()}
+                    </span>
+                    <TextField
+                      isRequired
+                      name="FieldName"
+                      value={formData?.FieldName}
+                      validate={() => (isFormInvalid ? validateUniqueField() : '')}
+                      onChange={(e) => handleFormFieldChange('FieldName', e)}
+                    />
+                  </Grid>
+                  <Grid size={6}>
+                    <span
+                      className={`bcds-react-aria-Select--Label ${isFormInvalid && !formData?.Area ? '--error' : ''}`}
+                    >
+                      Area
+                    </span>
+                    <TextField
+                      isRequired
+                      type="number"
+                      name="Area"
+                      value={formData?.Area?.toString()}
+                      onChange={(e) => handleFormFieldChange('Area', e?.trim())}
+                    />
+                  </Grid>
+
+                  <Grid size={6}>
+                    <span
+                      className={`bcds-react-aria-Select--Label ${isFormInvalid && !formData?.PreviousYearManureApplicationFrequency ? '--error' : ''}`}
+                    >
+                      Manure Application
+                    </span>
+                    <Select
+                      isRequired
+                      name="manureApplication"
+                      items={manureOptions}
+                      selectedKey={formData?.PreviousYearManureApplicationFrequency}
+                      onSelectionChange={(e) => {
+                        handleFormFieldChange(
+                          'PreviousYearManureApplicationFrequency',
+                          e.toString(),
+                        );
+                      }}
+                    />
+                  </Grid>
+                  <Grid size={6}>
+                    <span>Comment (Optional)</span>
+                    <TextField
+                      name="Comment"
+                      value={formData.Comment}
+                      onChange={(e) => handleFormFieldChange('Comment', e)}
+                    />
+                  </Grid>
+                </Grid>
+                <Divider
+                  aria-hidden="true"
+                  component="div"
+                  css={{ marginTop: '1rem', marginBottom: '1rem' }}
+                />
+                <ButtonGroup
+                  alignment="end"
+                  orientation="horizontal"
+                >
+                  <Button
+                    type="reset"
+                    variant="secondary"
+                    onPress={handleDialogClose}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    type="submit"
+                    variant="primary"
+                  >
+                    Confirm
+                  </Button>
+                </ButtonGroup>
+              </Form>
+            </div>
+          </Dialog>
+        </Modal>
+      </>
+      <TabsMaterial
+        activeTab={0}
+        tabLabel={['Field List', 'Soil Tests', 'Crops']}
+      />
+      <DataGrid
+        sx={{ ...customTableStyle, marginTop: '1.25rem' }}
+        rows={fieldList}
+        columns={columns}
+        disableRowSelectionOnClick
+        disableColumnMenu
+        hideFooterPagination
+        hideFooter
+      />
+      <ErrorText>{showViewError}</ErrorText>
+      <ButtonGroup
+        alignment="start"
+        ariaLabel="A group of buttons"
+        orientation="horizontal"
       >
-        {errors.FieldName && <ErrorText>{errors.FieldName}</ErrorText>}
-        <InputField
-          label="Field Name"
-          type="text"
-          name="FieldName"
-          value={fieldFormData.FieldName}
-          onChange={handleChange}
-        />
-        {errors.Area && <ErrorText>{errors.Area}</ErrorText>}
-        <InputField
-          label="Area"
-          type="text"
-          name="Area"
-          value={fieldFormData.Area}
-          onChange={handleChange}
-        />
-        {errors.PreviousYearManureApplicationFrequency && (
-          <ErrorText>{errors.PreviousYearManureApplicationFrequency}</ErrorText>
-        )}
-        <Dropdown
-          label="Manure application in previous years"
-          name="PreviousYearManureApplicationFrequency"
-          value={fieldFormData.PreviousYearManureApplicationFrequency}
-          options={manureOptions}
-          onChange={handleChange}
-        />
-        <InputField
-          label="Comments (optional)"
-          type="text"
-          name="Comment"
-          value={fieldFormData.Comment}
-          onChange={handleChange}
-        />
-      </Modal>
-    </ViewCard>
+        <Button
+          size="medium"
+          aria-label="Back"
+          variant="secondary"
+          onPress={() => navigate(FARM_INFORMATION)}
+        >
+          BACK
+        </Button>
+        <Button
+          size="medium"
+          aria-label="Next"
+          variant="primary"
+          onPress={handleNextPage}
+          type="submit"
+        >
+          Next
+        </Button>
+      </ButtonGroup>
+    </StyledContent>
   );
 }

--- a/frontend/src/views/FieldList/fieldList.styles.ts
+++ b/frontend/src/views/FieldList/fieldList.styles.ts
@@ -2,6 +2,8 @@
  * @summary Styling for FieldList view
  */
 import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+import { componentContainer, buttonGroup, paragraphCss } from '../../common.styles';
 
 export const ContentWrapper = styled.div<{ hasFields: boolean }>`
   margin-bottom: ${({ hasFields }) => (hasFields ? '170px' : '0')};
@@ -77,3 +79,51 @@ export const ListItem = styled.div<{ align?: string }>`
 export const ErrorText = styled.div`
   color: red;
 `;
+
+export const StyledContent = styled.div`
+  margin-bottom: 1rem;
+  ${componentContainer}
+
+  ${paragraphCss}
+
+  ${buttonGroup}
+`;
+
+export const subHeader = css({
+  fontWeight: '700',
+  size: '1.25rem',
+  lineHeight: '100%',
+  letterSpacing: '0px',
+});
+
+export const customTableStyle = {
+  borderStyle: 'none',
+  '& .MuiDataGrid-columnHeader > .MuiDataGrid-columnSeparator': {
+    visibility: 'hidden',
+  },
+  '& .MuiDataGrid-columnHeaders': {
+    borderBottom: 'none',
+  },
+  '& div div div div >.MuiDataGrid-cell': {
+    borderBottom: 'none',
+    borderTop: '1px solid rgba(224, 224, 224, 1)',
+  },
+  '& .MuiDataGrid-row:hover': {
+    backgroundColor: 'transparent',
+  },
+  '& .MuiDataGrid-columnHeaderTitle': {
+    fontWeight: '700',
+  },
+};
+
+export const tableActionButtonCss = css({
+  paddingLeft: '0.75rem',
+  color: 'var(--surface-color-primary-button-default)',
+});
+
+export default {
+  customTableStyle,
+  StyledContent,
+  subHeader,
+  tableActionButtonCss,
+};


### PR DESCRIPTION
## Pull Request Standards

- [X] The title of the PR is accurate
- [X] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [X] The PR title includes the ticket number in format of `[NMP-###]`
- [ ] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Added reusable component for Tabs ('Field List', 'Soil Tests', 'Crops')
- Added reusable component from Material UI library for field list table
- Added global styling for previous two components to be reused.
- Created new modal form for entering field information, with validation

![image](https://github.com/user-attachments/assets/db2d453e-7727-4eac-8219-8488409b7038)
![image](https://github.com/user-attachments/assets/e867d22c-5fb4-4f27-a7ea-f2d2125ac923)
![image](https://github.com/user-attachments/assets/d439d68a-1150-42c4-9e47-d68084101b63)
![image](https://github.com/user-attachments/assets/d051f95f-04d5-42a4-a976-a2384fd30324)


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-nmp-248.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-nmp-248-backend.apps.silver.devops.gov.bc.ca/healthcheck/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/merge.yml)