### PR TITLE
fix: Check that animals array is non-empty

### DIFF
--- a/frontend/src/views/ManureAndImports/ManureAndImports.tsx
+++ b/frontend/src/views/ManureAndImports/ManureAndImports.tsx
@@ -52,7 +52,7 @@ export default function ManureAndImports() {
       return JSON.parse(state.nmpFile);
     }
     // TODO: Once we cache state, throw error if uninitialized
-    return { ...defaultNMPFile, years: [{...defaultNMPFileYear}] };
+    return { ...defaultNMPFile, years: [{ ...defaultNMPFileYear }] };
   }, [state.nmpFile]);
   const navigate = useNavigate();
   const apiCache = useContext(APICacheContext);
@@ -246,7 +246,10 @@ export default function ManureAndImports() {
       setNMPFile(JSON.stringify(nmpFile));
     }
 
-    if (parsedFile.years[0]?.FarmAnimals !== undefined) {
+    if (
+      parsedFile.years[0]?.FarmAnimals !== undefined &&
+      parsedFile.years[0].FarmAnimals.length > 0
+    ) {
       navigate(ADD_ANIMALS);
     } else {
       navigate(CROPS);


### PR DESCRIPTION
## Pull Request Standards

- [ ] The title of the PR is accurate
- [ ] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [ ] The PR title includes the ticket number in format of `[NMP-###]`
- [ ] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Redirect in Manure and Imports checks if the animal array is non-empty