### PR TITLE
feat(NMP-300): Calculate Balance Row with Icons

### DIFF
--- a/frontend/public/dollar warning.svg
+++ b/frontend/public/dollar warning.svg
@@ -1,0 +1,8 @@
+<svg width="21" height="21" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" viewBox="0 0 21 21">
+  <!-- Created with SVG-edit - http://svg-edit.googlecode.com/ -->
+  <g>
+    <title>Layer 1</title>
+    <ellipse stroke="#e8bf0b" ry="8" rx="8" id="svg_2" cy="10.5" cx="10.5" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="5" fill="#e8bf0b"/>
+    <text stroke="#000000" transform="matrix(1.0635289025196357,0,0,0.7675392623715951,-73.34570528908733,-71.75840187177488) " font-weight="normal" xml:space="preserve" text-anchor="middle" font-family="Sans-serif" font-size="24" id="svg_4" y="115.506416" x="79.02201" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="0" fill="#7f7f7f">!</text>
+  </g>
+</svg>

--- a/frontend/public/good.svg
+++ b/frontend/public/good.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+  <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+  <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="18px" height="18px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <g transform="translate(0, 0)">
+      <path fill="#449d44" d="M12,0C5.4,0,0,5.4,0,12s5.4,12,12,12s12-5.4,12-12S18.6,0,12,0z M18.7,8.7l-8,8C10.5,16.9,10.3,17,10,17
+	s-0.5-0.1-0.7-0.3l-4-4c-0.4-0.4-0.4-1,0-1.4s1-0.4,1.4,0l3.3,3.3l7.3-7.3c0.4-0.4,1-0.4,1.4,0S19.1,8.3,18.7,8.7z"></path>
+    </g>
+  </svg>

--- a/frontend/public/stop triangle.svg
+++ b/frontend/public/stop triangle.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+  <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+  <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="18px" height="18px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <g transform="translate(0, 0)">
+      <path fill="#ff0f3f"  d="m 22.885,21.534 -10,-19 c -0.346,-0.657 -1.424,-0.657 -1.77,0 l -10,19 C 0.952,21.844 0.963,22.217 1.143,22.516 1.325,22.817 1.649,23 2,23 h 20 c 0.351,0 0.675,-0.183 0.856,-0.483 0.181,-0.3 0.192,-0.673 0.029,-0.983 z"></path>
+      </g>
+  </svg>

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -81,7 +81,8 @@ export const liquidSolidManureDisplay = (manureObj: { [key: string]: number | st
   return '0';
 };
 
-// use in CalculateNutrients.tsx
+// use in CalculateNutrients.tsx to show icon in balance row only
+// and makes crop nutrients display as a negative value
 export const renderNutrientCell = (
   balanceType: string,
   findBalanceMessage: (type: string, value: number) => { Icon?: string } | undefined,
@@ -103,6 +104,6 @@ export const renderNutrientCell = (
             }),
             React.createElement('span', { key: 'value' }, value),
           ]
-        : React.createElement('span', { style: { marginLeft: '1.5em' } }, value),
+        : React.createElement('span', { style: { marginLeft: '1.5em' } }, -value),
     );
   };

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import defaultNMPFileYear from '@/constants/DefaultNMPFileYear';
 import defaultNMPFile from '@/constants/DefaultNMPFile';
 import NMPFile from '@/types/NMPFile';
@@ -79,3 +80,29 @@ export const liquidSolidManureDisplay = (manureObj: { [key: string]: number | st
   }
   return '0';
 };
+
+// use in CalculateNutrients.tsx
+export const renderNutrientCell = (
+  balanceType: string,
+  findBalanceMessage: (type: string, value: number) => { Icon?: string } | undefined,
+) =>
+  function renderNutrientCellInner({ value, row }: any) {
+    const isBalanceRow = row.id === 'balance';
+    const message = isBalanceRow ? findBalanceMessage(balanceType, value) : null;
+
+    return React.createElement(
+      'div',
+      { style: { display: 'flex', alignItems: 'center' } },
+      message?.Icon
+        ? [
+            React.createElement('img', {
+              key: 'icon',
+              src: message.Icon,
+              alt: 'Balance icon',
+              style: { width: '1em', height: '1em', marginRight: '0.5em' },
+            }),
+            React.createElement('span', { key: 'value' }, value),
+          ]
+        : React.createElement('span', { style: { marginLeft: '1.5em' } }, value),
+    );
+  };

--- a/frontend/src/views/CalculateNutrients/CalculateNutrients.styles.ts
+++ b/frontend/src/views/CalculateNutrients/CalculateNutrients.styles.ts
@@ -82,3 +82,9 @@ export const addRecordGroupStyle = css({
     },
   },
 });
+
+export const Error = styled.div`
+  color: red;
+  font-size: 12px;
+  box-shadow: 0 0 2px red;
+`;

--- a/frontend/src/views/CalculateNutrients/CalculateNutrients.styles.ts
+++ b/frontend/src/views/CalculateNutrients/CalculateNutrients.styles.ts
@@ -84,6 +84,7 @@ export const addRecordGroupStyle = css({
 });
 
 export const Error = styled.div`
+  display: flex;
   border: 1px solid #c81212;
   width: 100%;
   margin-bottom: 9px;
@@ -92,9 +93,14 @@ export const Error = styled.div`
     0 0 45px rgba(255, 255, 255, 0.7) inset;
 `;
 
-export const Message = styled.p`
-  color: black;
+export const Message = styled.div`
+  display: flex;
+  color: black !important;
   font-size: 12px;
   font-weight: bold;
-  margin: 0.5em;
+  align-items: center;
+`;
+
+export const Icon = styled.img`
+  margin: 0.25em;
 `;

--- a/frontend/src/views/CalculateNutrients/CalculateNutrients.styles.ts
+++ b/frontend/src/views/CalculateNutrients/CalculateNutrients.styles.ts
@@ -84,7 +84,17 @@ export const addRecordGroupStyle = css({
 });
 
 export const Error = styled.div`
-  color: red;
+  border: 1px solid #c81212;
+  width: 100%;
+  margin-bottom: 9px;
+  box-shadow:
+    0 2px 3px rgba(0, 0, 0, 0.4),
+    0 0 45px rgba(255, 255, 255, 0.7) inset;
+`;
+
+export const Message = styled.p`
+  color: black;
   font-size: 12px;
-  box-shadow: 0 0 2px red;
+  font-weight: bold;
+  margin: 0.5em;
 `;

--- a/frontend/src/views/CalculateNutrients/CalculateNutrients.tsx
+++ b/frontend/src/views/CalculateNutrients/CalculateNutrients.tsx
@@ -8,17 +8,16 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTrash, faEdit, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { Button, ButtonGroup } from '@bcgov/design-system-react-components';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
-import { Icon } from '@mui/material';
 import useAppService from '@/services/app/useAppService';
 import { AppTitle, PageTitle, ProgressStepper, TabsMaterial } from '../../components/common';
 import { NMPFileFieldData } from '@/types/NMPFileFieldData';
 import { FIELD_LIST, CROPS } from '@/constants/RouteConstants';
+import { renderNutrientCell, initFields } from '../../utils/utils.ts';
 
 import { customTableStyle, tableActionButtonCss } from '../../common.styles';
 import { ErrorText, StyledContent } from '../FieldList/fieldList.styles';
-import { Error, Message } from './CalculateNutrients.styles';
+import { Error, Message, Icon } from './CalculateNutrients.styles';
 import { NutrientMessage, nutrientMessages } from './nutrientMessages';
-import { initFields } from '../../utils/utils';
 import NewFertilizerModal from './FertilizerModal/NewFertilizerModal';
 import ManureModal from './CalculateNutrientsComponents/ManureModal';
 import OtherModal from './CalculateNutrientsComponents/OtherModal';
@@ -60,17 +59,16 @@ export default function CalculateNutrients() {
   };
   const rowsWithBalance = crops.length > 0 ? [...crops, balanceRow] : [];
 
-  // Set balance messages array with appropriate messages based on the balances
-  const getMessage = useCallback((balanceType: string, balanceValue: number) => {
-    // Find the messages that matches the balanceType and balanceValue
-    const message = nutrientMessages.find(
+  const findBalanceMessage = (balanceType: string, balanceValue: number) =>
+    nutrientMessages.find(
       (msg) =>
         msg.BalanceType === balanceType &&
         balanceValue >= msg.ReqBalanceLow &&
         balanceValue <= msg.ReqBalanceHigh,
     );
-    // populates message with value to meet crop requirement
-    // sets balance messages
+
+  const getMessage = useCallback((balanceType: string, balanceValue: number) => {
+    const message = findBalanceMessage(balanceType, balanceValue);
     if (message) {
       setBalanceMessages((prev) => [
         ...prev,
@@ -83,7 +81,29 @@ export default function CalculateNutrients() {
     }
   }, []);
 
-  // When balance row changes, clear previous messages and calculate new balances and set new messages based on the balances
+  // // Set balance messages array with appropriate messages based on the balances
+  // const getMessage = useCallback((balanceType: string, balanceValue: number) => {
+  //   // Find the messages that matches the balanceType and balanceValue
+  //   const message = nutrientMessages.find(
+  //     (msg) =>
+  //       msg.BalanceType === balanceType &&
+  //       balanceValue >= msg.ReqBalanceLow &&
+  //       balanceValue <= msg.ReqBalanceHigh,
+  //   );
+  //   // sets balance messages with value to meet crop requirement
+  //   if (message) {
+  //     setBalanceMessages((prev) => [
+  //       ...prev,
+  //       {
+  //         ...message,
+  //         Text: message.Text.replace('{0}', Math.abs(balanceValue ?? 0).toFixed(1)),
+  //         Icon: message.Icon,
+  //       },
+  //     ]);
+  //   }
+  // }, []);
+
+  // When balance row changes, clear previous messages and set new messages
   useEffect(() => {
     setBalanceMessages([]);
 
@@ -146,56 +166,62 @@ export default function CalculateNutrients() {
       { field: 'cropName', headerName: 'Crop', width: 250, minWidth: 200, maxWidth: 300 },
       {
         field: 'reqN',
-        headerName: 'N',
+        headerName: '     N',
         width: 60,
         minWidth: 60,
         maxWidth: 100,
         description: 'Nitrogen',
+        renderCell: renderNutrientCell('reqN', findBalanceMessage),
       },
       {
         field: 'reqP2o5',
-        headerName: 'P2o5',
-        width: 60,
-        minWidth: 60,
+        headerName: '   P2o5',
+        width: 80,
+        minWidth: 80,
         maxWidth: 100,
         description: 'Phosphorous',
+        renderCell: renderNutrientCell('reqN', findBalanceMessage),
       },
       {
         field: 'reqK2o',
-        headerName: 'K2o',
-        width: 110,
-        minWidth: 100,
-        maxWidth: 110,
+        headerName: '     K2o',
+        width: 120,
+        minWidth: 120,
+        maxWidth: 100,
         description: 'Potassium',
+        renderCell: renderNutrientCell('reqN', findBalanceMessage),
       },
       {
         field: 'remN',
-        headerName: 'N',
-        width: 60,
-        minWidth: 60,
+        headerName: '        N',
+        width: 80,
+        minWidth: 80,
         maxWidth: 100,
         description: 'Nitrogen',
+        renderCell: renderNutrientCell('reqN', findBalanceMessage),
       },
       {
         field: 'remP2o5',
-        headerName: 'P2o5',
-        width: 60,
-        minWidth: 60,
+        headerName: '     P2o5',
+        width: 80,
+        minWidth: 80,
         maxWidth: 100,
         description: 'Phosphorous',
+        renderCell: renderNutrientCell('reqN', findBalanceMessage),
       },
       {
         field: 'remK2o',
-        headerName: 'K2o',
-        width: 180,
+        headerName: '     K2o',
+        width: 130,
         minWidth: 60,
-        maxWidth: 180,
+        maxWidth: 130,
         description: 'Potassium',
+        renderCell: renderNutrientCell('reqN', findBalanceMessage),
       },
       {
         field: '',
         headerName: 'Actions',
-        width: 120,
+        width: 100,
         renderCell: (row: any) => {
           // If balance row don't show actions
           const isBalanceRow = row.row.cropName === 'Balance';
@@ -363,8 +389,8 @@ export default function CalculateNutrients() {
       <div
         style={{ display: 'flex', fontWeight: 'bold', textAlign: 'center', marginTop: '1.25rem' }}
       >
-        <div style={{ width: 230 }} />
-        <div style={{ width: 210 }}>Agronomic (lb/ac)</div>
+        <div style={{ width: 220 }} />
+        <div style={{ width: 290 }}>Agronomic (lb/ac)</div>
         <div style={{ width: 250 }}>Crop Removal (lb/ac)</div>
       </div>
       {/* display crops belonging to the field of the tab the user is on */}
@@ -382,18 +408,10 @@ export default function CalculateNutrients() {
         <Error key={msg.Id}>
           {/* based on msg get appropriate icon // frontend/public/stop triangle.svg */}
           <Icon
-            key={msg.Id}
-            sx={{ width: '1.5rem', height: '1.5rem', marginRight: '0.5rem' }}
-            component="img"
             src={msg.Icon}
             alt="Nutrient balance icon"
           />
-          <img
-            key={msg.Id}
-            src={msg.Icon}
-            alt="Nutrient balance icon"
-          />
-          <Message key={msg.Id}>{msg.Text}</Message>
+          <Message>{msg.Text}</Message>
         </Error>
       ))}
       <ButtonGroup

--- a/frontend/src/views/CalculateNutrients/CalculateNutrients.tsx
+++ b/frontend/src/views/CalculateNutrients/CalculateNutrients.tsx
@@ -16,7 +16,7 @@ import { FIELD_LIST, CROPS } from '@/constants/RouteConstants';
 
 import { customTableStyle, tableActionButtonCss } from '../../common.styles';
 import { ErrorText, StyledContent } from '../FieldList/fieldList.styles';
-import { Error } from './CalculateNutrients.styles';
+import { Error, Message } from './CalculateNutrients.styles';
 import { NutrientMessage, nutrientMessages } from './nutrientMessages';
 import { initFields } from '../../utils/utils';
 import NewFertilizerModal from './FertilizerModal/NewFertilizerModal';
@@ -76,7 +76,7 @@ export default function CalculateNutrients() {
         ...prev,
         {
           ...message,
-          Text: message.Text.replace('{0}', Math.abs(balanceValue).toFixed(1)),
+          Text: message.Text.replace('{0}', Math.abs(balanceValue ?? 0).toFixed(1)),
           Icon: message.Icon,
         },
       ]);
@@ -85,23 +85,15 @@ export default function CalculateNutrients() {
 
   // When balance row changes, clear previous messages and calculate new balances and set new messages based on the balances
   useEffect(() => {
-    setBalanceMessages([]); // Clear previous messages
+    setBalanceMessages([]);
 
-    const balanceRow = {
-      id: 'balance',
-      cropName: 'Balance',
-      reqN: crops.reduce((sum, row) => sum + (row.reqN ?? 0), 0),
-      reqP2o5: crops.reduce((sum, row) => sum + (row.reqP2o5 ?? 0), 0),
-      reqK2o: crops.reduce((sum, row) => sum + (row.reqK2o ?? 0), 0),
-      remN: crops.reduce((sum, row) => sum + (row.remN ?? 0), 0),
-      remP2o5: crops.reduce((sum, row) => sum + (row.remP2o5 ?? 0), 0),
-      remK2o: crops.reduce((sum, row) => sum + (row.remK2o ?? 0), 0),
-    };
-    const rowsWithBalance = crops.length > 0 ? [...crops, balanceRow] : [];
-
-    Object.entries(balances).forEach(([type, value]) => {
-      getMessage(type, value);
-    });
+    // go over each balance value and get the appropriate message
+    getMessage('reqN', balanceRow.reqN);
+    getMessage('reqP2o5', balanceRow.reqP2o5);
+    getMessage('reqK2o', balanceRow.reqK2o);
+    getMessage('remN', balanceRow.remN);
+    getMessage('remP2o5', balanceRow.remP2o5);
+    getMessage('remK2o', balanceRow.remK2o);
   }, [balanceRow]);
 
   const handleEditRow = React.useCallback((e: { row: NMPFileFieldData }) => {
@@ -174,7 +166,7 @@ export default function CalculateNutrients() {
         width: 110,
         minWidth: 100,
         maxWidth: 110,
-        description: 'Nitrogen',
+        description: 'Potassium',
       },
       {
         field: 'remN',
@@ -190,7 +182,7 @@ export default function CalculateNutrients() {
         width: 60,
         minWidth: 60,
         maxWidth: 100,
-        description: 'Nitrogen',
+        description: 'Phosphorous',
       },
       {
         field: 'remK2o',
@@ -198,7 +190,7 @@ export default function CalculateNutrients() {
         width: 180,
         minWidth: 60,
         maxWidth: 180,
-        description: 'Nitrogen',
+        description: 'Potassium',
       },
       {
         field: '',
@@ -237,7 +229,7 @@ export default function CalculateNutrients() {
       <Button
         size="medium"
         aria-label="Add Field"
-        onPress={() => {
+        onClick={() => {
           setButtonClicked('field');
           setIsDialogOpen(true);
         }}
@@ -389,12 +381,19 @@ export default function CalculateNutrients() {
       {balanceMessages.map((msg) => (
         <Error key={msg.Id}>
           {/* based on msg get appropriate icon // frontend/public/stop triangle.svg */}
+          <Icon
+            key={msg.Id}
+            sx={{ width: '1.5rem', height: '1.5rem', marginRight: '0.5rem' }}
+            component="img"
+            src={msg.Icon}
+            alt="Nutrient balance icon"
+          />
           <img
             key={msg.Id}
             src={msg.Icon}
             alt="Nutrient balance icon"
           />
-          <ErrorText key={msg.Id}>{msg.Text}</ErrorText>
+          <Message key={msg.Id}>{msg.Text}</Message>
         </Error>
       ))}
       <ButtonGroup

--- a/frontend/src/views/CalculateNutrients/nutrientMessages.ts
+++ b/frontend/src/views/CalculateNutrients/nutrientMessages.ts
@@ -13,7 +13,7 @@ export const nutrientMessages: NutrientMessage[] = [
   {
     Id: 1,
     Text: 'Reduce N input by {0} lb/ac',
-    Icon: 'frontend/public/stop triangle.svg',
+    Icon: '/stop triangle.svg',
     BalanceType: 'reqN',
     ReqBalanceLow: 15,
     ReqBalanceHigh: 99999,
@@ -23,7 +23,7 @@ export const nutrientMessages: NutrientMessage[] = [
   {
     Id: 2,
     Text: 'Crop requirement for N is met',
-    Icon: 'frontend/public/good.svg',
+    Icon: '/good.svg',
     BalanceType: 'reqN',
     ReqBalanceLow: -5,
     ReqBalanceHigh: 14,
@@ -33,7 +33,7 @@ export const nutrientMessages: NutrientMessage[] = [
   {
     Id: 3,
     Text: 'Add {0} lb N/ac to meet crop requirements',
-    Icon: 'frontend/public/dollar warning.svg',
+    Icon: '/dollar warning.svg',
     BalanceType: 'reqN',
     ReqBalanceLow: -99999,
     ReqBalanceHigh: -6,
@@ -43,7 +43,7 @@ export const nutrientMessages: NutrientMessage[] = [
   {
     Id: 4,
     Text: 'Crop requirement for P2O5 is met; {0} lb/ac adds no benefit to the crop',
-    Icon: 'frontend/public/dollar warning.svg',
+    Icon: '/dollar warning.svg',
     BalanceType: 'reqP2o5',
     ReqBalanceLow: 15,
     ReqBalanceHigh: 99999,
@@ -53,7 +53,7 @@ export const nutrientMessages: NutrientMessage[] = [
   {
     Id: 5,
     Text: 'Crop requirement for P2O5 is met',
-    Icon: 'frontend/public/good.svg',
+    Icon: '/good.svg',
     BalanceType: 'reqP2o5',
     ReqBalanceLow: -5,
     ReqBalanceHigh: 14,
@@ -63,7 +63,7 @@ export const nutrientMessages: NutrientMessage[] = [
   {
     Id: 6,
     Text: 'Add {0} lb P2O5/ac to meet crop requirements',
-    Icon: 'frontend/public/dollar warning.svg',
+    Icon: '/dollar warning.svg',
     BalanceType: 'reqP2o5',
     ReqBalanceLow: -99999,
     ReqBalanceHigh: -6,
@@ -73,7 +73,7 @@ export const nutrientMessages: NutrientMessage[] = [
   {
     Id: 7,
     Text: 'Crop requirement for K2O is met, {0} lb/ac adds no benefit to the crop',
-    Icon: 'frontend/public/dollar warning.svg',
+    Icon: '/dollar warning.svg',
     BalanceType: 'reqK2o',
     ReqBalanceLow: 15,
     ReqBalanceHigh: 99999,
@@ -83,7 +83,7 @@ export const nutrientMessages: NutrientMessage[] = [
   {
     Id: 8,
     Text: 'Crop requirement for K2O is met',
-    Icon: 'frontend/public/good.svg',
+    Icon: '/good.svg',
     BalanceType: 'reqK2o',
     ReqBalanceLow: -5,
     ReqBalanceHigh: 14,
@@ -93,7 +93,7 @@ export const nutrientMessages: NutrientMessage[] = [
   {
     Id: 9,
     Text: 'Add {0} lb K2O/ac to meet crop requirements',
-    Icon: 'frontend/public/dollar warning.svg',
+    Icon: '/dollar warning.svg',
     BalanceType: 'reqK2o',
     ReqBalanceLow: -99999,
     ReqBalanceHigh: -6,
@@ -103,7 +103,7 @@ export const nutrientMessages: NutrientMessage[] = [
   {
     Id: 10,
     Text: 'Reduce crop P2O5 removal balance below 80 lb/ac per year in the long term.',
-    Icon: 'frontend/public/stop triangle.svg',
+    Icon: '/stop triangle.svg',
     BalanceType: 'remP2O5',
     ReqBalanceLow: 15,
     ReqBalanceHigh: 99999,

--- a/frontend/src/views/CalculateNutrients/nutrientMessages.ts
+++ b/frontend/src/views/CalculateNutrients/nutrientMessages.ts
@@ -1,0 +1,113 @@
+export interface NutrientMessage {
+  Id: number;
+  Text: string;
+  Icon: string;
+  BalanceType: string;
+  ReqBalanceLow: number;
+  ReqBalanceHigh: number;
+  RemBalanceLow: number;
+  RemBalanceHigh: number;
+}
+
+export const nutrientMessages: NutrientMessage[] = [
+  {
+    Id: 1,
+    Text: 'Reduce N input by {0} lb/ac',
+    Icon: 'frontend/public/stop triangle.svg',
+    BalanceType: 'reqN',
+    ReqBalanceLow: 15,
+    ReqBalanceHigh: 99999,
+    RemBalanceLow: 0,
+    RemBalanceHigh: 0,
+  },
+  {
+    Id: 2,
+    Text: 'Crop requirement for N is met',
+    Icon: 'frontend/public/good.svg',
+    BalanceType: 'reqN',
+    ReqBalanceLow: -5,
+    ReqBalanceHigh: 14,
+    RemBalanceLow: 0,
+    RemBalanceHigh: 0,
+  },
+  {
+    Id: 3,
+    Text: 'Add {0} lb N/ac to meet crop requirements',
+    Icon: 'frontend/public/dollar warning.svg',
+    BalanceType: 'reqN',
+    ReqBalanceLow: -99999,
+    ReqBalanceHigh: -6,
+    RemBalanceLow: 0,
+    RemBalanceHigh: 0,
+  },
+  {
+    Id: 4,
+    Text: 'Crop requirement for P2O5 is met; {0} lb/ac adds no benefit to the crop',
+    Icon: 'frontend/public/dollar warning.svg',
+    BalanceType: 'reqP2o5',
+    ReqBalanceLow: 15,
+    ReqBalanceHigh: 99999,
+    RemBalanceLow: 0,
+    RemBalanceHigh: 0,
+  },
+  {
+    Id: 5,
+    Text: 'Crop requirement for P2O5 is met',
+    Icon: 'frontend/public/good.svg',
+    BalanceType: 'reqP2o5',
+    ReqBalanceLow: -5,
+    ReqBalanceHigh: 14,
+    RemBalanceLow: 0,
+    RemBalanceHigh: 0,
+  },
+  {
+    Id: 6,
+    Text: 'Add {0} lb P2O5/ac to meet crop requirements',
+    Icon: 'frontend/public/dollar warning.svg',
+    BalanceType: 'reqP2o5',
+    ReqBalanceLow: -99999,
+    ReqBalanceHigh: -6,
+    RemBalanceLow: 0,
+    RemBalanceHigh: 0,
+  },
+  {
+    Id: 7,
+    Text: 'Crop requirement for K2O is met, {0} lb/ac adds no benefit to the crop',
+    Icon: 'frontend/public/dollar warning.svg',
+    BalanceType: 'reqK2o',
+    ReqBalanceLow: 15,
+    ReqBalanceHigh: 99999,
+    RemBalanceLow: 0,
+    RemBalanceHigh: 0,
+  },
+  {
+    Id: 8,
+    Text: 'Crop requirement for K2O is met',
+    Icon: 'frontend/public/good.svg',
+    BalanceType: 'reqK2o',
+    ReqBalanceLow: -5,
+    ReqBalanceHigh: 14,
+    RemBalanceLow: 0,
+    RemBalanceHigh: 0,
+  },
+  {
+    Id: 9,
+    Text: 'Add {0} lb K2O/ac to meet crop requirements',
+    Icon: 'frontend/public/dollar warning.svg',
+    BalanceType: 'reqK2o',
+    ReqBalanceLow: -99999,
+    ReqBalanceHigh: -6,
+    RemBalanceLow: 0,
+    RemBalanceHigh: 0,
+  },
+  {
+    Id: 10,
+    Text: 'Reduce crop P2O5 removal balance below 80 lb/ac per year in the long term.',
+    Icon: 'frontend/public/stop triangle.svg',
+    BalanceType: 'remP2O5',
+    ReqBalanceLow: 15,
+    ReqBalanceHigh: 99999,
+    RemBalanceLow: 80,
+    RemBalanceHigh: 99999,
+  },
+];


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [ ] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Added a balance row which shows the sum of each column when there are crops
- In agronomic nutrient columns the balance row displays icons
- Warnings appear under the table when there is an imbalance, these do not appear when the crop is good

Production AGRI-NMP vs NR-NMP
![Screenshot 2025-06-10 at 3 05 35 PM](https://github.com/user-attachments/assets/26184f58-dbc6-43da-94eb-c00472f87772)
![Screenshot 2025-06-10 at 3 05 40 PM](https://github.com/user-attachments/assets/68513587-15d4-4b0d-bb2a-a1414e5209a4)
