### PR TITLE
fix: [NR-NMP-339] Years array is preserved by Farm Information page

### DIFF
--- a/frontend/src/hooks/reducers/appStateReducer.ts
+++ b/frontend/src/hooks/reducers/appStateReducer.ts
@@ -137,17 +137,19 @@ export function appStateReducer(state: AppState, action: AppStateAction): AppSta
 
   if (action.type === 'SAVE_FARM_DETAILS') {
     // Years *is* an array, but we don't like that and cheat to make it a single-value array
-    if (action.newFarmDetails.Year === newAppState.nmpFile.years[0].Year) {
-      if (
-        action.newFarmDetails.FarmAnimals === undefined ||
-        action.newFarmDetails.FarmAnimals.length === 0
-      ) {
-        // Clear the animals array if animals have been removed
-        saveAnimals(newAppState.nmpFile.years[0], []);
-      }
-    } else {
-      // Replace the years array with a blank year
+    // Make new blank year if no year exists or if we have a different year saved
+    if (
+      newAppState.nmpFile.years.length === 0 ||
+      action.newFarmDetails.Year !== newAppState.nmpFile.years[0].Year
+    ) {
       newAppState.nmpFile.years = [{ ...DEFAULT_NMPFILE_YEAR, Year: action.newFarmDetails.Year }];
+      // Otherwise, keep the existing year and edit as necessary
+    } else if (
+      action.newFarmDetails.FarmAnimals === undefined ||
+      action.newFarmDetails.FarmAnimals.length === 0
+    ) {
+      // Clear the animals array if animals have been removed
+      saveAnimals(newAppState.nmpFile.years[0], []);
     }
     newAppState.nmpFile.farmDetails = structuredClone(action.newFarmDetails);
     saveDataToLocalStorage(NMP_FILE_KEY, newAppState.nmpFile);

--- a/frontend/src/types/AppState.ts
+++ b/frontend/src/types/AppState.ts
@@ -1,4 +1,4 @@
-import NMPFile from './NMPFile';
+import { NMPFile } from './NMPFile';
 
 type AppState = {
   nmpFile: NMPFile;

--- a/frontend/src/types/NMPFile.ts
+++ b/frontend/src/types/NMPFile.ts
@@ -1,18 +1,15 @@
 import NMPFileYear from './NMPFileYear';
-/**
- * @summary Type definitions for NMP File
- */
-type NMPFile = {
-  farmDetails: {
-    Year: string;
-    FarmName: string;
-    FarmRegion: number;
-    FarmSubRegion?: number | null;
-    FarmAnimals?: string[];
-    HasHorticulturalCrops?: boolean;
-    HasBerries?: boolean;
-    HasVegetables?: boolean;
-    /*
+
+export type NMPFileFarmDetails = {
+  Year: string;
+  FarmName: string;
+  FarmRegion: number;
+  FarmSubRegion?: number | null;
+  FarmAnimals?: string[];
+  HasHorticulturalCrops?: boolean;
+  HasBerries?: boolean;
+  HasVegetables?: boolean;
+  /*
     Fields from old NMP, currently unused, feel free to re-add
     Manure?: any | null;
     HasSelectedFarmType?: boolean;
@@ -23,7 +20,13 @@ type NMPFile = {
     LeafTestingMethod?: any | null;
     UserJourney?: number;
     */
-  };
+};
+
+/**
+ * @summary Type definitions for NMP File
+ */
+export type NMPFile = {
+  farmDetails: NMPFileFarmDetails;
   years: NMPFileYear[];
   /*
   Fields from old NMP, currently unused, feel free to re-add
@@ -32,4 +35,3 @@ type NMPFile = {
   NMPReleaseVersion?: number;
   */
 };
-export default NMPFile;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,6 +1,6 @@
 import AppState from './AppState';
 import LiquidManureConversionFactors from './LiquidManureConversionFactors';
-import NMPFile from './NMPFile';
+import { NMPFile, NMPFileFarmDetails } from './NMPFile';
 import { SelectOption } from './Common';
 import {
   CropsConversionFactors,
@@ -47,6 +47,7 @@ export type {
   SelectOption,
   LiquidManureConversionFactors,
   NMPFile,
+  NMPFileFarmDetails,
   NMPFileYear,
   NMPFileFieldData,
   NMPFileImportedManureData,


### PR DESCRIPTION
## Pull Request Standards

- [ ] The title of the PR is accurate
- [ ] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [ ] The PR title includes the ticket number in format of `[NMP-###]`
- [ ] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Cleaned up init logic in FarmInformation
- Made NMPFileFarmDetails type
- Added action to reducer to set farmDetails. Does the same thing as it did previously if there is a year mismatch, but edits the existing year object if the years match

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-nmp-341.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-nmp-341-backend.apps.silver.devops.gov.bc.ca/healthcheck/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/merge.yml)