### PR TITLE
fix: [NR-NMP-342] Save edits made on calculate nutrients page

### DIFF
--- a/frontend/src/views/CalculateNutrients/CalculateNutrients.tsx
+++ b/frontend/src/views/CalculateNutrients/CalculateNutrients.tsx
@@ -36,7 +36,7 @@ import { CalculateNutrientsColumn } from '@/types/calculateNutrients.ts';
 import CropsModal from '../Crops/CropsModal.tsx';
 
 export default function CalculateNutrients() {
-  const { state } = useAppState();
+  const { state, dispatch } = useAppState();
   const [openDialog, setOpenDialog] = useState<[string, number | undefined]>(['', undefined]);
   const [showViewError, setShowViewError] = useState<string>('');
   const [activeField, setActiveField] = useState<number>(0);
@@ -127,6 +127,11 @@ export default function CalculateNutrients() {
 
   const handleNextPage = () => {
     setShowViewError('');
+    dispatch({
+      type: 'SAVE_FIELDS',
+      year: state.nmpFile.farmDetails.Year!,
+      newFields: fieldList,
+    });
 
     navigate(REPORTING);
   };
@@ -427,6 +432,11 @@ export default function CalculateNutrients() {
           aria-label="Back"
           variant="secondary"
           onPress={() => {
+            dispatch({
+              type: 'SAVE_FIELDS',
+              year: state.nmpFile.farmDetails.Year!,
+              newFields: fieldList,
+            });
             if (activeField > 0) {
               setActiveField(activeField - 1);
             } else {


### PR DESCRIPTION
## Pull Request Standards

- [X] The title of the PR is accurate
- [X] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [X] The PR title includes the ticket number in format of `[NMP-###]`
- [X] Documentation is updated to reflect change

# Description
Calculate Nutrients page saves fields on navigating to away from it.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-nmp-343.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-nmp-343-backend.apps.silver.devops.gov.bc.ca/healthcheck/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/merge.yml)