### PR TITLE
feat: [NR-NMP-301] Stepper Update

### DIFF
--- a/frontend/src/components/common/ProgressStepper/ProgressStepper.test.tsx
+++ b/frontend/src/components/common/ProgressStepper/ProgressStepper.test.tsx
@@ -17,7 +17,7 @@ jest.mock('@/hooks/useAppState');
 const mockUseAppService = jest.mocked(useAppState);
 
 describe('ProgressStepper tests', () => {
-  test('Animal step absent when showAnimalsStep is false', () => {
+  test('Only the Home and Farm Information steps should be visible initially', () => {
     mockUseAppService.mockImplementation(() => ({
       state: { nmpFile: DEFAULT_NMPFILE, showAnimalsStep: false },
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -28,11 +28,13 @@ describe('ProgressStepper tests', () => {
         <ProgressStepper />
       </BrowserRouter>,
     );
-    const elem = screen.queryByText('Animals and Manure');
-    expect(elem).toBeNull();
+    const elem1 = screen.queryByText('Home');
+    const elem2 = screen.queryByText('Farm Information');
+    expect(elem1).toBeInTheDocument();
+    expect(elem2).toBeInTheDocument();
   });
 
-  test('Animal step present when showAnimalsStep is true', () => {
+  test('All other steps should not be present initially', () => {
     mockUseAppService.mockImplementation(() => ({
       state: { nmpFile: DEFAULT_NMPFILE, showAnimalsStep: true },
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -43,7 +45,13 @@ describe('ProgressStepper tests', () => {
         <ProgressStepper />
       </BrowserRouter>,
     );
-    const elem = screen.getByText('Animals and Manure');
-    expect(elem).toBeInTheDocument();
+    const elem1 = screen.getByText('Animals and Manure');
+    const elem2 = screen.getByText('Fields and Soil');
+    const elem3 = screen.getByText('Calculate Nutrients');
+    const elem4 = screen.getByText('Reporting');
+    expect(elem1).toBeNull();
+    expect(elem2).toBeNull();
+    expect(elem3).toBeNull();
+    expect(elem4).toBeNull();
   });
 });

--- a/frontend/src/components/common/ProgressStepper/ProgressStepper.test.tsx
+++ b/frontend/src/components/common/ProgressStepper/ProgressStepper.test.tsx
@@ -45,10 +45,10 @@ describe('ProgressStepper tests', () => {
         <ProgressStepper />
       </BrowserRouter>,
     );
-    const elem1 = screen.getByText('Animals and Manure');
-    const elem2 = screen.getByText('Fields and Soil');
-    const elem3 = screen.getByText('Calculate Nutrients');
-    const elem4 = screen.getByText('Reporting');
+    const elem1 = screen.queryByText('Animals and Manure');
+    const elem2 = screen.queryByText('Fields and Soil');
+    const elem3 = screen.queryByText('Calculate Nutrients');
+    const elem4 = screen.queryByText('Reporting');
     expect(elem1).toBeNull();
     expect(elem2).toBeNull();
     expect(elem3).toBeNull();

--- a/frontend/src/components/common/ProgressStepper/ProgressStepper.tsx
+++ b/frontend/src/components/common/ProgressStepper/ProgressStepper.tsx
@@ -43,7 +43,10 @@ export default function ProgressStepper() {
     if (state.showAnimalsStep) {
       return [
         ...baseSteps,
-        { name: 'Animals and Manure', paths: [ADD_ANIMALS, MANURE_IMPORTS, STORAGE, NUTRIENT_ANALYSIS] },
+        {
+          name: 'Animals and Manure',
+          paths: [ADD_ANIMALS, MANURE_IMPORTS, STORAGE, NUTRIENT_ANALYSIS],
+        },
         { name: 'Fields and Soil', paths: [FIELD_LIST, SOIL_TESTS, CROPS] },
         { name: 'Calculate Nutrients', paths: [CALCULATE_NUTRIENTS] },
         { name: 'Reporting', paths: [REPORTING] },

--- a/frontend/src/views/AddAnimals/AddAnimals.tsx
+++ b/frontend/src/views/AddAnimals/AddAnimals.tsx
@@ -71,6 +71,10 @@ export default function AddAnimals() {
     }
   };
 
+  const handlePreviousPage = () => {
+    navigate(FARM_INFORMATION);
+  };
+
   // Same columns are in ManureAndImports.tsx
   const columns: GridColDef[] = useMemo(
     () => [
@@ -173,7 +177,7 @@ export default function AddAnimals() {
           size="medium"
           aria-label="Back"
           variant="secondary"
-          onPress={() => navigate(FARM_INFORMATION)}
+          onPress={handlePreviousPage}
         >
           BACK
         </Button>

--- a/frontend/src/views/CalculateNutrients/CalculateNutrients.tsx
+++ b/frontend/src/views/CalculateNutrients/CalculateNutrients.tsx
@@ -34,7 +34,6 @@ import {
 } from './utils.tsx';
 import { CalculateNutrientsColumn } from '@/types/calculateNutrients.ts';
 import CropsModal from '../Crops/CropsModal.tsx';
-import { AnimalData } from '@/types/Animals.ts';
 
 export default function CalculateNutrients() {
   const { state } = useAppState();
@@ -42,7 +41,6 @@ export default function CalculateNutrients() {
   const [showViewError, setShowViewError] = useState<string>('');
   const [activeField, setActiveField] = useState<number>(0);
   const [balanceMessages, setBalanceMessages] = useState<Array<NutrientMessage>>([]);
-  const [animalList] = useState<Array<AnimalData>>(state.nmpFile.years[0]?.FarmAnimals || []);
 
   const navigate = useNavigate();
 
@@ -138,7 +136,7 @@ export default function CalculateNutrients() {
       setActiveField(activeField - 1);
     }
 
-    if (animalList.length === 0) {
+    if (!state.showAnimalsStep) {
       navigate(NUTRIENT_ANALYSIS);
     } else {
       navigate(CROPS);

--- a/frontend/src/views/CalculateNutrients/CalculateNutrients.tsx
+++ b/frontend/src/views/CalculateNutrients/CalculateNutrients.tsx
@@ -13,7 +13,7 @@ import Grid from '@mui/material/Grid';
 import useAppState from '@/hooks/useAppState';
 import { AppTitle, PageTitle, ProgressStepper, TabsMaterial } from '../../components/common';
 import { NMPFileFieldData } from '@/types/NMPFileFieldData';
-import { CROPS, REPORTING } from '@/constants/routes';
+import { CROPS, NUTRIENT_ANALYSIS, REPORTING } from '@/constants/routes';
 
 import { customTableStyle } from '../../common.styles';
 import { ErrorText, StyledContent } from '../FieldList/fieldList.styles';
@@ -34,6 +34,7 @@ import {
 } from './utils.tsx';
 import { CalculateNutrientsColumn } from '@/types/calculateNutrients.ts';
 import CropsModal from '../Crops/CropsModal.tsx';
+import { AnimalData } from '@/types/Animals.ts';
 
 export default function CalculateNutrients() {
   const { state } = useAppState();
@@ -41,6 +42,7 @@ export default function CalculateNutrients() {
   const [showViewError, setShowViewError] = useState<string>('');
   const [activeField, setActiveField] = useState<number>(0);
   const [balanceMessages, setBalanceMessages] = useState<Array<NutrientMessage>>([]);
+  const [animalList] = useState<Array<AnimalData>>(state.nmpFile.years[0]?.FarmAnimals || []);
 
   const navigate = useNavigate();
 
@@ -129,6 +131,18 @@ export default function CalculateNutrients() {
     setShowViewError('');
 
     navigate(REPORTING);
+  };
+
+  const handlePreviousPage = () => {
+    if (activeField > 0) {
+      setActiveField(activeField - 1);
+    }
+
+    if (animalList.length === 0) {
+      navigate(NUTRIENT_ANALYSIS);
+    } else {
+      navigate(CROPS);
+    }
   };
 
   const customCalcTableStyle = {
@@ -426,13 +440,7 @@ export default function CalculateNutrients() {
           size="medium"
           aria-label="Back"
           variant="secondary"
-          onPress={() => {
-            if (activeField > 0) {
-              setActiveField(activeField - 1);
-            } else {
-              navigate(CROPS);
-            }
-          }}
+          onPress={handlePreviousPage}
         >
           BACK
         </Button>

--- a/frontend/src/views/Crops/Crops.tsx
+++ b/frontend/src/views/Crops/Crops.tsx
@@ -15,8 +15,13 @@ import { GridApiCommunity } from '@mui/x-data-grid/internals';
 import useAppState from '@/hooks/useAppState';
 import { AppTitle, PageTitle, ProgressStepper, TabsMaterial } from '../../components/common';
 import { StyledContent } from './crops.styles';
-import { NMPFileFieldData } from '@/types';
-import { CALCULATE_NUTRIENTS, SOIL_TESTS, FARM_INFORMATION } from '@/constants/routes';
+import { AnimalData, NMPFileFieldData } from '@/types';
+import {
+  CALCULATE_NUTRIENTS,
+  SOIL_TESTS,
+  FARM_INFORMATION,
+  MANURE_IMPORTS,
+} from '@/constants/routes';
 import { customTableStyle, tableActionButtonCss } from '../../common.styles';
 import CropsModal from './CropsModal';
 
@@ -33,6 +38,7 @@ function Crops() {
   const [editingFieldIndex, setEditingFieldIndex] = useState<number>(0);
   const [editingCropIndex, setEditingCropIndex] = useState<number | undefined>(undefined);
   const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
+  const [animalList] = useState<Array<AnimalData>>(state.nmpFile.years[0]?.FarmAnimals || []);
 
   const handleEditCrop = (e: { id: GridRowId; api: GridApiCommunity }, cropIndex: number) => {
     setEditingFieldIndex(e.api.getRowIndexRelativeToVisibleRows(e.id));
@@ -55,7 +61,11 @@ function Crops() {
       navigate(FARM_INFORMATION);
     }
     dispatch({ type: 'SAVE_FIELDS', year: state.nmpFile.farmDetails.Year!, newFields: fields });
-    navigate(CALCULATE_NUTRIENTS);
+    if (animalList.length === 0) {
+      navigate(MANURE_IMPORTS);
+    } else {
+      navigate(CALCULATE_NUTRIENTS);
+    }
   };
 
   const handlePrevious = () => {

--- a/frontend/src/views/Crops/Crops.tsx
+++ b/frontend/src/views/Crops/Crops.tsx
@@ -15,7 +15,7 @@ import { GridApiCommunity } from '@mui/x-data-grid/internals';
 import useAppState from '@/hooks/useAppState';
 import { AppTitle, PageTitle, ProgressStepper, TabsMaterial } from '../../components/common';
 import { StyledContent } from './crops.styles';
-import { AnimalData, NMPFileFieldData } from '@/types';
+import { NMPFileFieldData } from '@/types';
 import {
   CALCULATE_NUTRIENTS,
   SOIL_TESTS,
@@ -38,7 +38,6 @@ function Crops() {
   const [editingFieldIndex, setEditingFieldIndex] = useState<number>(0);
   const [editingCropIndex, setEditingCropIndex] = useState<number | undefined>(undefined);
   const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
-  const [animalList] = useState<Array<AnimalData>>(state.nmpFile.years[0]?.FarmAnimals || []);
 
   const handleEditCrop = (e: { id: GridRowId; api: GridApiCommunity }, cropIndex: number) => {
     setEditingFieldIndex(e.api.getRowIndexRelativeToVisibleRows(e.id));
@@ -61,7 +60,7 @@ function Crops() {
       navigate(FARM_INFORMATION);
     }
     dispatch({ type: 'SAVE_FIELDS', year: state.nmpFile.farmDetails.Year!, newFields: fields });
-    if (animalList.length === 0) {
+    if (!state.showAnimalsStep) {
       navigate(MANURE_IMPORTS);
     } else {
       navigate(CALCULATE_NUTRIENTS);

--- a/frontend/src/views/Crops/Crops.tsx
+++ b/frontend/src/views/Crops/Crops.tsx
@@ -55,7 +55,7 @@ function Crops() {
     });
   };
 
-  const handleNext = () => {
+  const handleNextPage = () => {
     if (!state.nmpFile.farmDetails.Year) {
       // We should show an error popup, but for now force-navigate back to Farm Information
       navigate(FARM_INFORMATION);
@@ -68,7 +68,7 @@ function Crops() {
     }
   };
 
-  const handlePrevious = () => {
+  const handlePreviousPage = () => {
     navigate(SOIL_TESTS);
   };
 
@@ -234,7 +234,7 @@ function Crops() {
           size="medium"
           aria-label="Back"
           variant="secondary"
-          onClick={handlePrevious}
+          onClick={handlePreviousPage}
         >
           BACK
         </Button>
@@ -242,7 +242,7 @@ function Crops() {
           size="medium"
           aria-label="Next"
           variant="primary"
-          onClick={handleNext}
+          onClick={handleNextPage}
           type="submit"
         >
           Next

--- a/frontend/src/views/FarmInformation/FarmInformation.tsx
+++ b/frontend/src/views/FarmInformation/FarmInformation.tsx
@@ -199,6 +199,10 @@ export default function FarmInformation() {
     }
   };
 
+  const handlePeviousPage = () => {
+    navigate(LANDING_PAGE);
+  };
+
   return (
     <StyledContent>
       <ProgressStepper />
@@ -340,7 +344,7 @@ export default function FarmInformation() {
           <Button
             size="medium"
             aria-label="Back"
-            onPress={() => navigate(LANDING_PAGE)}
+            onPress={handlePeviousPage}
             variant="secondary"
           >
             BACK

--- a/frontend/src/views/FieldList/FieldList.tsx
+++ b/frontend/src/views/FieldList/FieldList.tsx
@@ -12,15 +12,17 @@ import { AppTitle, PageTitle, ProgressStepper, TabsMaterial } from '../../compon
 import { addRecordGroupStyle, customTableStyle, tableActionButtonCss } from '../../common.styles';
 import { ErrorText, StyledContent } from './fieldList.styles';
 import { NMPFileFieldData } from '@/types/NMPFileFieldData';
-import { FARM_INFORMATION, MANURE_IMPORTS, SOIL_TESTS } from '@/constants/routes';
+import { FARM_INFORMATION, NUTRIENT_ANALYSIS, SOIL_TESTS } from '@/constants/routes';
 import useAppState from '@/hooks/useAppState';
 import FieldListModal from '../../components/common/FieldListModal/FieldListModal';
+import { AnimalData } from '@/types';
 
 export default function FieldList() {
   const { state, dispatch } = useAppState();
   const [rowEditIndex, setRowEditIndex] = useState<number | undefined>(undefined);
   const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
   const [showViewError, setShowViewError] = useState<string>('');
+  const [animalList] = useState<Array<AnimalData>>(state.nmpFile.years[0]?.FarmAnimals || []);
 
   const navigate = useNavigate();
 
@@ -66,13 +68,10 @@ export default function FieldList() {
 
   const handleBack = () => {
     try {
-      if (
-        state.nmpFile.farmDetails.FarmAnimals === undefined ||
-        state.nmpFile.farmDetails.FarmAnimals.length === 0
-      ) {
+      if (animalList.length === 0) {
         navigate(FARM_INFORMATION);
       } else {
-        navigate(MANURE_IMPORTS);
+        navigate(NUTRIENT_ANALYSIS);
       }
     } catch {
       console.log("Couldn't parse");

--- a/frontend/src/views/FieldList/FieldList.tsx
+++ b/frontend/src/views/FieldList/FieldList.tsx
@@ -15,14 +15,12 @@ import { NMPFileFieldData } from '@/types/NMPFileFieldData';
 import { FARM_INFORMATION, NUTRIENT_ANALYSIS, SOIL_TESTS } from '@/constants/routes';
 import useAppState from '@/hooks/useAppState';
 import FieldListModal from '../../components/common/FieldListModal/FieldListModal';
-import { AnimalData } from '@/types';
 
 export default function FieldList() {
   const { state, dispatch } = useAppState();
   const [rowEditIndex, setRowEditIndex] = useState<number | undefined>(undefined);
   const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
   const [showViewError, setShowViewError] = useState<string>('');
-  const [animalList] = useState<Array<AnimalData>>(state.nmpFile.years[0]?.FarmAnimals || []);
 
   const navigate = useNavigate();
 
@@ -68,7 +66,7 @@ export default function FieldList() {
 
   const handlePreviousPage = () => {
     try {
-      if (animalList.length === 0) {
+      if (!state.showAnimalsStep) {
         navigate(FARM_INFORMATION);
       } else {
         navigate(NUTRIENT_ANALYSIS);

--- a/frontend/src/views/FieldList/FieldList.tsx
+++ b/frontend/src/views/FieldList/FieldList.tsx
@@ -66,7 +66,7 @@ export default function FieldList() {
     }
   };
 
-  const handleBack = () => {
+  const handlePreviousPage = () => {
     try {
       if (animalList.length === 0) {
         navigate(FARM_INFORMATION);
@@ -174,7 +174,7 @@ export default function FieldList() {
           size="medium"
           aria-label="Back"
           variant="secondary"
-          onPress={handleBack}
+          onPress={handlePreviousPage}
         >
           BACK
         </Button>

--- a/frontend/src/views/ManureAndImports/ManureAndImports.tsx
+++ b/frontend/src/views/ManureAndImports/ManureAndImports.tsx
@@ -33,6 +33,7 @@ import { addRecordGroupStyle, customTableStyle, tableActionButtonCss } from '@/c
 import ManureImportModal from './ManureImportModal';
 import { booleanChecker, liquidSolidManureDisplay } from '@/utils/utils';
 
+// Create a new component for crops manure and imports for now
 export default function ManureAndImports() {
   const { state, dispatch } = useAppState();
   const navigate = useNavigate();
@@ -148,7 +149,7 @@ export default function ManureAndImports() {
 
   useEffect(() => {
     // Load animals step to progress stepper
-    dispatch({ type: 'SET_SHOW_ANIMALS_STEP', showAnimalsStep: true });
+    // dispatch({ type: 'SET_SHOW_ANIMALS_STEP', showAnimalsStep: true });
 
     apiCache
       .callEndpoint('api/liquidmaterialsconversionfactors/')
@@ -307,7 +308,11 @@ export default function ManureAndImports() {
     <StyledContent>
       <ProgressStepper />
       <AppTitle />
-      <PageTitle title="Manure & Imports" />
+      {animalList.length > 0 ? (
+        <PageTitle title="Animals and Manure" />
+      ) : (
+        <PageTitle title="Manure and Compost" />
+      )}
       <>
         <div css={addRecordGroupStyle}>
           <ButtonGovGroup
@@ -335,21 +340,30 @@ export default function ManureAndImports() {
           onOpenChange={handleDialogClose}
           isDismissable
         />
-        <TabsMaterial
-          activeTab={1}
-          tabLabel={['Add Animals', 'Manure & Imports', 'Nutrient Analysis']}
-        />
+        {animalList.length > 0 ? (
+          <TabsMaterial
+            activeTab={1}
+            tabLabel={['Add Animals', 'Manure & Imports', 'Nutrient Analysis']}
+          />
+        ) : (
+          <TabsMaterial
+            activeTab={0}
+            tabLabel={['Manure & Imports', 'Nutrient Analysis']}
+          />
+        )}
       </>
-      <DataGrid
-        sx={{ ...customTableStyle, marginTop: '1.25rem' }}
-        rows={animalList}
-        columns={columnsAnimalManure}
-        getRowId={() => crypto.randomUUID()}
-        disableRowSelectionOnClick
-        disableColumnMenu
-        hideFooterPagination
-        hideFooter
-      />
+      {animalList.length > 0 ? (
+        <DataGrid
+          sx={{ ...customTableStyle, marginTop: '1.25rem' }}
+          rows={animalList}
+          columns={columnsAnimalManure}
+          getRowId={() => crypto.randomUUID()}
+          disableRowSelectionOnClick
+          disableColumnMenu
+          hideFooterPagination
+          hideFooter
+        />
+      ) : null}
       <DataGrid
         sx={{ ...customTableStyle, marginTop: '1.25rem' }}
         rows={manures}

--- a/frontend/src/views/ManureAndImports/ManureAndImports.tsx
+++ b/frontend/src/views/ManureAndImports/ManureAndImports.tsx
@@ -26,7 +26,13 @@ import {
 import { getDensityFactoredConversionUsingMoisture } from '@/calculations/ManureAndCompost/ManureAndImports/Calculations';
 import { StyledContent } from './manureAndImports.styles';
 import useAppState from '@/hooks/useAppState';
-import { ADD_ANIMALS, CROPS, FARM_INFORMATION, NUTRIENT_ANALYSIS, STORAGE } from '@/constants/routes';
+import {
+  ADD_ANIMALS,
+  CROPS,
+  FARM_INFORMATION,
+  NUTRIENT_ANALYSIS,
+  STORAGE,
+} from '@/constants/routes';
 
 import { AppTitle, PageTitle, ProgressStepper, TabsMaterial } from '../../components/common';
 import { addRecordGroupStyle, customTableStyle, tableActionButtonCss } from '@/common.styles';

--- a/frontend/src/views/ManureAndImports/ManureAndImports.tsx
+++ b/frontend/src/views/ManureAndImports/ManureAndImports.tsx
@@ -123,15 +123,7 @@ export default function ManureAndImports() {
     }
   };
 
-  const handlePrevious = () => {
-    if (animalList.length > 0) {
-      navigate(ADD_ANIMALS);
-    } else {
-      navigate(CROPS);
-    }
-  };
-
-  const handleNext = () => {
+  const handleNextPage = () => {
     if (!state.nmpFile.farmDetails.Year) {
       // We should show an error popup, but for now force-navigate back to Farm Information
       navigate(FARM_INFORMATION);
@@ -142,6 +134,14 @@ export default function ManureAndImports() {
       newManures: manures,
     });
     navigate(NUTRIENT_ANALYSIS);
+  };
+
+  const handlePreviousPage = () => {
+    if (animalList.length > 0) {
+      navigate(ADD_ANIMALS);
+    } else {
+      navigate(CROPS);
+    }
   };
 
   useEffect(() => {
@@ -380,7 +380,7 @@ export default function ManureAndImports() {
           size="medium"
           aria-label="Back"
           variant="secondary"
-          onPress={handlePrevious}
+          onPress={handlePreviousPage}
         >
           BACK
         </Button>
@@ -388,7 +388,7 @@ export default function ManureAndImports() {
           size="medium"
           aria-label="Next"
           variant="primary"
-          onPress={handleNext}
+          onPress={handleNextPage}
           type="submit"
         >
           Next

--- a/frontend/src/views/ManureAndImports/ManureAndImports.tsx
+++ b/frontend/src/views/ManureAndImports/ManureAndImports.tsx
@@ -137,7 +137,7 @@ export default function ManureAndImports() {
   };
 
   const handlePreviousPage = () => {
-    if (animalList.length > 0) {
+    if (state.showAnimalsStep) {
       navigate(ADD_ANIMALS);
     } else {
       navigate(CROPS);
@@ -145,9 +145,6 @@ export default function ManureAndImports() {
   };
 
   useEffect(() => {
-    // Load animals step to progress stepper
-    // dispatch({ type: 'SET_SHOW_ANIMALS_STEP', showAnimalsStep: true });
-
     apiCache
       .callEndpoint('api/liquidmaterialsconversionfactors/')
       .then((response: { status?: any; data: any }) => {
@@ -305,7 +302,7 @@ export default function ManureAndImports() {
     <StyledContent>
       <ProgressStepper />
       <AppTitle />
-      {animalList.length > 0 ? (
+      {state.showAnimalsStep ? (
         <PageTitle title="Animals and Manure" />
       ) : (
         <PageTitle title="Manure and Compost" />
@@ -337,7 +334,7 @@ export default function ManureAndImports() {
           onOpenChange={handleDialogClose}
           isDismissable
         />
-        {animalList.length > 0 ? (
+        {state.showAnimalsStep ? (
           <TabsMaterial
             activeTab={1}
             tabLabel={['Add Animals', 'Manure & Imports', 'Nutrient Analysis']}
@@ -349,7 +346,7 @@ export default function ManureAndImports() {
           />
         )}
       </>
-      {animalList.length > 0 ? (
+      {state.showAnimalsStep ? (
         <DataGrid
           sx={{ ...customTableStyle, marginTop: '1.25rem' }}
           rows={animalList}

--- a/frontend/src/views/ManureAndImports/ManureAndImports.tsx
+++ b/frontend/src/views/ManureAndImports/ManureAndImports.tsx
@@ -26,7 +26,7 @@ import {
 import { getDensityFactoredConversionUsingMoisture } from '@/calculations/ManureAndCompost/ManureAndImports/Calculations';
 import { StyledContent } from './manureAndImports.styles';
 import useAppState from '@/hooks/useAppState';
-import { ADD_ANIMALS, FARM_INFORMATION, NUTRIENT_ANALYSIS } from '@/constants/routes';
+import { ADD_ANIMALS, CROPS, FARM_INFORMATION, NUTRIENT_ANALYSIS } from '@/constants/routes';
 
 import { AppTitle, PageTitle, ProgressStepper, TabsMaterial } from '../../components/common';
 import { addRecordGroupStyle, customTableStyle, tableActionButtonCss } from '@/common.styles';
@@ -124,13 +124,10 @@ export default function ManureAndImports() {
   };
 
   const handlePrevious = () => {
-    if (
-      state.nmpFile.years[0]?.FarmAnimals !== undefined &&
-      state.nmpFile.years[0].FarmAnimals.length > 0
-    ) {
+    if (animalList.length > 0) {
       navigate(ADD_ANIMALS);
     } else {
-      navigate(FARM_INFORMATION);
+      navigate(CROPS);
     }
   };
 

--- a/frontend/src/views/NutrientAnalysis/NutrientAnalysis.tsx
+++ b/frontend/src/views/NutrientAnalysis/NutrientAnalysis.tsx
@@ -10,9 +10,9 @@ import { DataGrid, GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
 import { Button, Button as ButtonGov, ButtonGroup } from '@bcgov/design-system-react-components';
 import { AppTitle, PageTitle, ProgressStepper, TabsMaterial } from '../../components/common';
 import { StyledContent } from './nutrientAnalsysis.styles';
-import { NMPFileImportedManureData } from '@/types';
+import { AnimalData, NMPFileImportedManureData } from '@/types';
 import useAppState from '@/hooks/useAppState';
-import { MANURE_IMPORTS, FIELD_LIST } from '@/constants/routes';
+import { MANURE_IMPORTS, FIELD_LIST, CALCULATE_NUTRIENTS } from '@/constants/routes';
 import { NMPFileFarmManureData } from '@/types/NMPFileFarmManureData';
 import NMPFileGeneratedManureData from '@/types/NMPFileGeneratedManureData';
 import { addRecordGroupStyle, customTableStyle, tableActionButtonCss } from '@/common.styles';
@@ -20,6 +20,7 @@ import NutrientAnalysisModal from './NutrientAnalysisModal';
 
 export default function NutrientAnalysis() {
   const { state, dispatch } = useAppState();
+  const [animalList] = useState<Array<AnimalData>>(state.nmpFile.years[0]?.FarmAnimals || []);
 
   const manures: (NMPFileImportedManureData | NMPFileGeneratedManureData)[] = useMemo(
     () =>
@@ -79,7 +80,11 @@ export default function NutrientAnalysis() {
       year: state.nmpFile.farmDetails.Year!,
       newManures: nutrientAnalysisData,
     });
-    navigate(FIELD_LIST);
+    if (animalList.length === 0) {
+      navigate(CALCULATE_NUTRIENTS);
+    } else {
+      navigate(FIELD_LIST);
+    }
   };
 
   const nutrientTableColumns: GridColDef[] = useMemo(
@@ -194,10 +199,17 @@ export default function NutrientAnalysis() {
           modalStyle={{ width: '700px' }}
         />
       )}
-      <TabsMaterial
-        activeTab={2}
-        tabLabel={['Add Animals', 'Manure & Imports', 'Nutrient Analysis']}
-      />
+      {animalList.length > 0 ? (
+        <TabsMaterial
+          activeTab={2}
+          tabLabel={['Add Animals', 'Manure & Imports', 'Nutrient Analysis']}
+        />
+      ) : (
+        <TabsMaterial
+          activeTab={1}
+          tabLabel={['Manure & Imports', 'Nutrient Analysis']}
+        />
+      )}
       <DataGrid
         sx={{ ...customTableStyle, marginTop: '1.25rem' }}
         rows={nutrientAnalysisData.map((ele) => ({ ...ele, ...ele.Nutrients }))}

--- a/frontend/src/views/NutrientAnalysis/NutrientAnalysis.tsx
+++ b/frontend/src/views/NutrientAnalysis/NutrientAnalysis.tsx
@@ -2,7 +2,7 @@
  * @summary The nutrient analysis tab on the manure page for the application
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEdit, faTrash } from '@fortawesome/free-solid-svg-icons';
@@ -44,13 +44,6 @@ export default function NutrientAnalysis() {
       state.nmpFile.years[0]?.FarmAnimals?.some((animal: AnimalData) => animal.animalId === '2'),
     [state.nmpFile.years],
   );
-
-  const activeTab = useMemo(() => (hasDairyCattle ? 3 : 2), [hasDairyCattle]);
-
-  useEffect(() => {
-    dispatch({ type: 'SET_SHOW_ANIMALS_STEP', showAnimalsStep: true });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const handleEdit = (name: string) => {
     setEditName(name);
@@ -215,22 +208,22 @@ export default function NutrientAnalysis() {
           modalStyle={{ width: '700px' }}
         />
       )}
-        {state.showAnimalsStep && hasDairyCattle ? (
-          <TabsMaterial
-            activeTab={3}
-            tabLabel={['Add Animals', 'Manure & Imports', 'Storage', 'Nutrient Analysis']}
-          />
-        ) : state.showAnimalsStep ? (
-          <TabsMaterial
-            activeTab={2}
-            tabLabel={['Add Animals', 'Manure & Imports', 'Nutrient Analysis']}
-          />
-        ) : (
-          <TabsMaterial
-            activeTab={1}
-            tabLabel={['Manure & Imports', 'Nutrient Analysis']}
-          />
-        )}
+      {state.showAnimalsStep && hasDairyCattle ? (
+        <TabsMaterial
+          activeTab={3}
+          tabLabel={['Add Animals', 'Manure & Imports', 'Storage', 'Nutrient Analysis']}
+        />
+      ) : state.showAnimalsStep ? (
+        <TabsMaterial
+          activeTab={2}
+          tabLabel={['Add Animals', 'Manure & Imports', 'Nutrient Analysis']}
+        />
+      ) : (
+        <TabsMaterial
+          activeTab={1}
+          tabLabel={['Manure & Imports', 'Nutrient Analysis']}
+        />
+      )}
       <DataGrid
         sx={{ ...customTableStyle, marginTop: '1.25rem' }}
         rows={nutrientAnalysisData.map((ele) => ({ ...ele, ...ele.Nutrients }))}

--- a/frontend/src/views/NutrientAnalysis/NutrientAnalysis.tsx
+++ b/frontend/src/views/NutrientAnalysis/NutrientAnalysis.tsx
@@ -70,11 +70,7 @@ export default function NutrientAnalysis() {
     setEditName(null);
   };
 
-  const handlePrevious = () => {
-    navigate(MANURE_IMPORTS);
-  };
-
-  const handleNext = () => {
+  const handleNextPage = () => {
     dispatch({
       type: 'SAVE_FARM_MANURE',
       year: state.nmpFile.farmDetails.Year!,
@@ -85,6 +81,10 @@ export default function NutrientAnalysis() {
     } else {
       navigate(FIELD_LIST);
     }
+  };
+
+  const handlePreviousPage = () => {
+    navigate(MANURE_IMPORTS);
   };
 
   const nutrientTableColumns: GridColDef[] = useMemo(
@@ -229,7 +229,7 @@ export default function NutrientAnalysis() {
           size="medium"
           aria-label="Back"
           variant="secondary"
-          onPress={handlePrevious}
+          onPress={handlePreviousPage}
         >
           BACK
         </Button>
@@ -237,7 +237,7 @@ export default function NutrientAnalysis() {
           size="medium"
           aria-label="Next"
           variant="primary"
-          onPress={handleNext}
+          onPress={handleNextPage}
           type="submit"
         >
           Next

--- a/frontend/src/views/NutrientAnalysis/NutrientAnalysis.tsx
+++ b/frontend/src/views/NutrientAnalysis/NutrientAnalysis.tsx
@@ -10,7 +10,7 @@ import { DataGrid, GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
 import { Button, Button as ButtonGov, ButtonGroup } from '@bcgov/design-system-react-components';
 import { AppTitle, PageTitle, ProgressStepper, TabsMaterial } from '../../components/common';
 import { StyledContent } from './nutrientAnalsysis.styles';
-import { AnimalData, NMPFileImportedManureData } from '@/types';
+import { NMPFileImportedManureData } from '@/types';
 import useAppState from '@/hooks/useAppState';
 import { MANURE_IMPORTS, FIELD_LIST, CALCULATE_NUTRIENTS } from '@/constants/routes';
 import { NMPFileFarmManureData } from '@/types/NMPFileFarmManureData';
@@ -20,7 +20,6 @@ import NutrientAnalysisModal from './NutrientAnalysisModal';
 
 export default function NutrientAnalysis() {
   const { state, dispatch } = useAppState();
-  const [animalList] = useState<Array<AnimalData>>(state.nmpFile.years[0]?.FarmAnimals || []);
 
   const manures: (NMPFileImportedManureData | NMPFileGeneratedManureData)[] = useMemo(
     () =>
@@ -76,7 +75,7 @@ export default function NutrientAnalysis() {
       year: state.nmpFile.farmDetails.Year!,
       newManures: nutrientAnalysisData,
     });
-    if (animalList.length === 0) {
+    if (!state.showAnimalsStep) {
       navigate(CALCULATE_NUTRIENTS);
     } else {
       navigate(FIELD_LIST);
@@ -199,7 +198,7 @@ export default function NutrientAnalysis() {
           modalStyle={{ width: '700px' }}
         />
       )}
-      {animalList.length > 0 ? (
+      {state.showAnimalsStep ? (
         <TabsMaterial
           activeTab={2}
           tabLabel={['Add Animals', 'Manure & Imports', 'Nutrient Analysis']}

--- a/frontend/src/views/Reporting/Reporting.tsx
+++ b/frontend/src/views/Reporting/Reporting.tsx
@@ -28,6 +28,10 @@ export default function FieldList() {
     URL.revokeObjectURL(url);
   }
 
+  const handlePreviousPage = () => {
+    navigate(CALCULATE_NUTRIENTS);
+  };
+
   return (
     <StyledContent>
       <ProgressStepper />
@@ -81,9 +85,7 @@ export default function FieldList() {
           size="medium"
           aria-label="Back"
           variant="secondary"
-          onPress={() => {
-            navigate(CALCULATE_NUTRIENTS);
-          }}
+          onPress={handlePreviousPage}
         >
           BACK
         </Button>

--- a/frontend/src/views/SoilTests/SoilTests.tsx
+++ b/frontend/src/views/SoilTests/SoilTests.tsx
@@ -171,12 +171,12 @@ export default function SoilTests() {
     handleDialogClose();
   };
 
-  const handleNext = () => {
+  const handleNextPage = () => {
     dispatch({ type: 'SAVE_FIELDS', year: state.nmpFile.farmDetails.Year!, newFields: fields });
     navigate(CROPS);
   };
 
-  const handlePrevious = () => {
+  const handlePreviousPage = () => {
     navigate(FIELD_LIST);
   };
 
@@ -456,7 +456,7 @@ export default function SoilTests() {
           size="medium"
           aria-label="Back"
           variant="secondary"
-          onPress={handlePrevious}
+          onPress={handlePreviousPage}
         >
           BACK
         </Button>
@@ -464,7 +464,7 @@ export default function SoilTests() {
           size="medium"
           aria-label="Next"
           variant="primary"
-          onPress={handleNext}
+          onPress={handleNextPage}
           type="submit"
         >
           Next


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Updated stepper component to handle animals and crops workflow
- Added conditional rendering in manure section to handle differences between animals and crops
- Updated stepper to only show initial steps until a path is actually selected (similar to old NMP)
- Updated navigation to conditional handle next and previous buttons properly

To test, go through an animals workflow, and a crops workflow and you should see the differences! When doing animals and crops together, it will appear as the animals workflow like in old NMP.

Additional information:
- If you decide to test with Dairy Cattle, the "Storage" tab will appear in the "Manure" section. If you then navigate backwards from "Nutrient Analysis" to "Storage", the page whites out. I'll look into it more as I finish the second part of this ticket, but when I opened the Storage file, it appeared to be a work in progress.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-nmp-344.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-nmp-344-backend.apps.silver.devops.gov.bc.ca/healthcheck/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/merge.yml)