### PR TITLE
fix: [NR-NMP-357] Disable Calculate Button when Crop is Other

### DIFF
--- a/frontend/src/views/Crops/CropsModal.tsx
+++ b/frontend/src/views/Crops/CropsModal.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../common.styles';
 import { ModalProps } from '@/components/common/Modal/Modal';
 import { DEFAULT_NMPFILE_CROPS, HarvestUnit } from '@/constants';
-import { CROP_OTHER_ID } from '@/types/Crops';
+import { CROP_OTHER_ID, CROP_TYPE_OTHER_ID } from '@/types/Crops';
 import { HARVEST_UNIT_OPTIONS } from '../../constants/harvestUnits';
 import useAppState from '@/hooks/useAppState';
 import { cropsModalReducer, showUnitDropdown } from './utils';
@@ -164,6 +164,16 @@ function CropsModal({
 
     onClose();
   };
+
+  // When crop is Other calculate button is disabled
+  // To enable submit button setCalculationsPerformed to true for Other
+  useEffect(() => {
+    if (selectedCropType?.id === CROP_TYPE_OTHER_ID) {
+      setCalculationsPerformed(true);
+    } else {
+      setCalculationsPerformed(false);
+    }
+  }, [selectedCropType]);
 
   // On load, make API calls to initialize reducer state values
   useEffect(() => {
@@ -737,6 +747,8 @@ function CropsModal({
             onPress={handleCalculate}
             isDisabled={
               // TODO: Hide button and enable Submit if this is a custom crop
+              // If other crop hide button
+              selectedCropType?.id === CROP_TYPE_OTHER_ID ||
               selectedCropType === undefined ||
               (selectedCrop === undefined && !selectedCropType.customcrop)
             }

--- a/frontend/src/views/Crops/CropsModal.tsx
+++ b/frontend/src/views/Crops/CropsModal.tsx
@@ -164,7 +164,7 @@ function CropsModal({
     // Yield validation - required and must be positive number
     if (!formData.yield) {
       newErrors.yield = 'Yield is required';
-    } else if (Number.isNaN(Number(formData.yield)) || Number(formData.yield) <= 0) {
+    } else if (Number.isFinite(formData.yield) || Number(formData.yield) <= 0) {
       newErrors.yield = 'Yield must be a valid number greater than zero';
     }
 
@@ -200,7 +200,6 @@ function CropsModal({
       newErrors.name = 'Please specify a name';
     }
 
-    console.log('formData.name', formData);
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };

--- a/frontend/src/views/Crops/CropsModal.tsx
+++ b/frontend/src/views/Crops/CropsModal.tsx
@@ -765,8 +765,6 @@ function CropsModal({
             variant="primary"
             onPress={handleCalculate}
             isDisabled={
-              // TODO: Hide button and enable Submit if this is a custom crop
-              // If other crop hide button
               selectedCropType?.id === CROP_TYPE_OTHER_ID ||
               selectedCropType === undefined ||
               (selectedCrop === undefined && !selectedCropType.customcrop)


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [ ] Documentation is updated to reflect change

# Description
Other crop type skips calculate step. It's not needed as the user enters their own nutrient numbers.

This PR includes the following proposed change(s):

- When crop type is 'Other' calculate button is disabled
- When crop type is 'Other' submit button is enabled
<img width="770" height="477" alt="Screenshot 2025-07-15 at 9 00 25 AM" src="https://github.com/user-attachments/assets/fb1e3cee-bf15-4a6c-b83e-b8a3f75a9585" />

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-nmp-371.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-nmp-371-backend.apps.silver.devops.gov.bc.ca/healthcheck/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/merge.yml)