### PR TITLE
feat(NMP-327): Liquid Storage Modal

### DIFF
--- a/frontend/src/types/NMPFileManureStorageSystem.ts
+++ b/frontend/src/types/NMPFileManureStorageSystem.ts
@@ -11,11 +11,26 @@ export type ManureInSystem =
       data: NMPFileImportedManureData;
     };
 
+export type StorageShapes = 'Rectangular' | 'Circular' | 'SlopedWallRectangular';
+
 export type ManureStorage = {
   id: number;
   name: string;
   isStructureCovered: boolean;
   uncoveredAreaSqFt?: number;
+  SelectedStorageStructureShape: StorageShapes;
+  RectangularLength?: number;
+  RectangularWidth?: number;
+  RectangularHeight?: number;
+  CircularDiameter?: number;
+  CircularHeight?: number;
+  SlopedWallTopLength?: number;
+  SlopedWallTopWidth?: number;
+  SlopedWallHeight?: number;
+  SlopedWallSlopeOfWall?: number;
+  surfaceArea?: number;
+  volumeUSGallons?: number;
+  volumeOfStorageStructure?: string;
 };
 
 export type NMPFileManureStorageSystem = {
@@ -23,7 +38,14 @@ export type NMPFileManureStorageSystem = {
   manureType?: ManureType;
   manuresInSystem: ManureInSystem[];
   // TODO: Change these as they become relevant
-  getsRunoffFromRoofsOrYards: false;
-  runoffAreaSqFt: null;
+  getsRunoffFromRoofsOrYards: boolean;
+  runoffAreaSqFt: number;
+  IsThereSolidLiquidSeparation: boolean;
+  PercentageOfLiquidVolumeSeparated: number;
+  SeparatedLiquidsUSGallons: number;
+  SeparatedSolidsTons: number;
   manureStorageStructures: ManureStorage;
+  // AnnualPrecipitation: number;
+  // AssignedWithNutrientAnalysis: boolean;
+  // ManureStorageVolume: string;
 };

--- a/frontend/src/views/Reporting/Reporting.tsx
+++ b/frontend/src/views/Reporting/Reporting.tsx
@@ -3,7 +3,7 @@ import { jsPDF } from 'jspdf';
 import { Button, ButtonGroup } from '@bcgov/design-system-react-components';
 import Grid from '@mui/material/Grid';
 import { useNavigate } from 'react-router-dom';
-import { SectionHeader, StyledContent, Error } from './reporting.styles';
+import { SectionHeader, StyledContent } from './reporting.styles';
 import { AppTitle, PageTitle, ProgressStepper } from '../../components/common';
 import { CALCULATE_NUTRIENTS } from '@/constants/routes';
 import CompleteReportTemplate from './ReportTemplates/CompleteReportTemplate';
@@ -11,7 +11,6 @@ import RecordKeepingSheets from './ReportTemplates/RecordKeepingSheetsTemplate';
 
 import useAppState from '@/hooks/useAppState';
 import { ManureInSystem } from '@/types';
-import { formGridBreakpoints } from '@/common.styles';
 
 export default function FieldList() {
   const reportRef = useRef(null);
@@ -25,14 +24,14 @@ export default function FieldList() {
     const importedManures = state.nmpFile?.years[0].ImportedManures || [];
     const unassignedM: ManureInSystem[] = [];
     const assignedM: ManureInSystem[] = [];
-    (generatedManures || []).forEach((manure) => {
+    generatedManures.forEach((manure) => {
       if (manure.AssignedToStoredSystem) {
         assignedM.push({ type: 'Generated', data: manure });
       } else {
         unassignedM.push({ type: 'Generated', data: manure });
       }
     });
-    (importedManures || []).forEach((manure) => {
+    importedManures.forEach((manure) => {
       if (manure.AssignedToStoredSystem) {
         assignedM.push({ type: 'Imported', data: manure });
       } else {
@@ -127,7 +126,7 @@ export default function FieldList() {
             The following materials are not stored:
             <ul>
               {unassignedManures.map((manure) => (
-                <span key={`${manure.type}-${manure.data?.ManagedManureName}`}>
+                <span key={`${manure.data?.ManagedManureName}`}>
                   {manure.type} - {manure.data?.ManagedManureName}
                 </span>
               ))}

--- a/frontend/src/views/Reporting/Reporting.tsx
+++ b/frontend/src/views/Reporting/Reporting.tsx
@@ -123,16 +123,16 @@ export default function FieldList() {
           container
           sx={{ marginTop: '1rem' }}
         >
-          <Error>
-            The following manures have not been assigned:
+          <div style={{ border: '1px solid #c81212', width: '100%' }}>
+            The following materials are not stored:
             <ul>
-              {unassignedManures.map((manure, idx) => (
-                <span key={`${manure.type}-${manure.data?.ManureName || idx}`}>
-                  {manure.type} - {manure.data?.ManureName || 'Unnamed'}
+              {unassignedManures.map((manure) => (
+                <span key={`${manure.type}-${manure.data?.ManagedManureName}`}>
+                  {manure.type} - {manure.data?.ManagedManureName}
                 </span>
               ))}
             </ul>
-          </Error>
+          </div>
         </Grid>
       )}
 

--- a/frontend/src/views/Storage/Storage.tsx
+++ b/frontend/src/views/Storage/Storage.tsx
@@ -195,7 +195,6 @@ export default function Storage() {
           variant="primary"
           onPress={handleNext}
           type="submit"
-          isDisabled={unassignedManures.length > 0}
         >
           Next
         </Button>

--- a/frontend/src/views/Storage/StorageModal.tsx
+++ b/frontend/src/views/Storage/StorageModal.tsx
@@ -16,7 +16,7 @@ import { formCss, formGridBreakpoints } from '../../common.styles';
 import MANURE_TYPE_OPTIONS from '@/constants/ManureTypeOptions';
 import YesNoRadioButtons from '@/components/common/YesNoRadioButtons/YesNoRadioButtons';
 import useAppState from '@/hooks/useAppState';
-import { ManureInSystem, ManureStorage, NMPFileManureStorageSystem } from '@/types';
+import { ManureInSystem, ManureStorage, ManureType, NMPFileManureStorageSystem } from '@/types';
 import DEFAULT_NMPFILE_MANURE_STORAGE from '@/constants/DefaultNMPFileManureStorage';
 import { Modal, Select } from '@/components/common';
 import { ModalProps } from '@/components/common/Modal/Modal';
@@ -184,7 +184,7 @@ export default function StorageModal({
             container
             size={12}
           >
-            {formData.manureType === 1 && (
+            {formData.manureType === ManureType.Liquid && (
               <>
                 <Grid
                   container
@@ -226,7 +226,7 @@ export default function StorageModal({
           css={{ marginTop: '1rem', marginBottom: '1rem' }}
         />
 
-        {formData.manureType === 1 && (
+        {formData.manureType === ManureType.Liquid && (
           <Grid
             container
             size={formGridBreakpoints}
@@ -261,11 +261,11 @@ export default function StorageModal({
                       type="number"
                       value={String(formData.PercentageOfLiquidVolumeSeparated)}
                       onChange={(e: string) => {
-                        handleInputChange({ PercentageOfLiquidVolumeSeparated: Number(e) });
                         const solidsSeparatedGallons = totalManureGallons * (Number(e) / 100);
                         const separatedLiquidsGallons = totalManureGallons - solidsSeparatedGallons;
                         const separatedSolidsTons = (solidsSeparatedGallons / 264.172) * 0.5;
                         handleInputChange({
+                          PercentageOfLiquidVolumeSeparated: Number(e),
                           SeparatedLiquidsUSGallons: Math.round(separatedLiquidsGallons),
                           SeparatedSolidsTons: Math.round(separatedSolidsTons),
                         });
@@ -328,18 +328,19 @@ export default function StorageModal({
               }}
               orientation="horizontal"
             />
-            {!formData.manureStorageStructures.isStructureCovered && formData.manureType === 2 && (
-              <TextField
-                isRequired
-                label="Uncovered Area of Storage (ft2)"
-                type="number"
-                value={String(formData.manureStorageStructures.uncoveredAreaSqFt)}
-                onChange={(e: string) => {
-                  handleStorageChange({ uncoveredAreaSqFt: Number(e) });
-                }}
-              />
-            )}
-            {formData.manureType === 1 && (
+            {!formData.manureStorageStructures.isStructureCovered &&
+              formData.manureType === ManureType.Solid && (
+                <TextField
+                  isRequired
+                  label="Uncovered Area of Storage (ft2)"
+                  type="number"
+                  value={String(formData.manureStorageStructures.uncoveredAreaSqFt)}
+                  onChange={(e: string) => {
+                    handleStorageChange({ uncoveredAreaSqFt: Number(e) });
+                  }}
+                />
+              )}
+            {formData.manureType === ManureType.Liquid && (
               <Select
                 isRequired
                 label="Storage shape"

--- a/frontend/src/views/Storage/StorageModal.tsx
+++ b/frontend/src/views/Storage/StorageModal.tsx
@@ -12,7 +12,7 @@ import {
   Form,
   TextField,
 } from '@bcgov/design-system-react-components';
-import { formCss } from '../../common.styles';
+import { formCss, formGridBreakpoints } from '../../common.styles';
 import MANURE_TYPE_OPTIONS from '@/constants/ManureTypeOptions';
 import YesNoRadioButtons from '@/components/common/YesNoRadioButtons/YesNoRadioButtons';
 import useAppState from '@/hooks/useAppState';
@@ -27,6 +27,12 @@ type ModalComponentProps = {
   unassignedManures: ManureInSystem[];
   handleDialogClose: () => void;
 };
+
+const storageShapeOptions = [
+  { id: '1', label: 'Rectangular' },
+  { id: '2', label: 'Circular' },
+  { id: '3', label: 'SlopedWallRectangular' },
+];
 
 export default function StorageModal({
   initialModalData,
@@ -48,6 +54,15 @@ export default function StorageModal({
     [...unassignedManures, ...formData.manuresInSystem].sort((a, b) =>
       a.data.ManagedManureName.localeCompare(b.data.ManagedManureName),
     ),
+  );
+  // get sum of all entered manures, used for solid and liquid seperation
+  const totalManureGallons = useMemo(
+    () =>
+      fullManureList.reduce(
+        (sum, manure) => sum + (manure.data.AnnualAmountUSGallonsVolume || 0),
+        0,
+      ),
+    [fullManureList],
   );
 
   const availableManures: ManureInSystem[] = useMemo(
@@ -108,6 +123,7 @@ export default function StorageModal({
       onOpenChange={handleDialogClose}
       title="Storage System Details"
       {...props}
+      modalStyle={{ width: '700px' }}
     >
       <Form
         css={formCss}
@@ -115,122 +131,340 @@ export default function StorageModal({
       >
         <Grid
           container
+          size={formGridBreakpoints}
+          direction="row"
           spacing={2}
-          size={12}
         >
           <Grid
             container
-            size={12}
-            direction="row"
+            size={6}
           >
-            <Grid
-              container
-              size={5}
+            <Select
+              isRequired
+              label="Manure Type"
+              selectedKey={formData.manureType}
+              items={MANURE_TYPE_OPTIONS}
+              onSelectionChange={(e: Key) => {
+                handleInputChange({ manureType: e as number, manuresInSystem: [] });
+                setFullManureList((prev) =>
+                  prev.map((m) => ({ ...m, data: { ...m.data, AssignedToStoredSystem: false } })),
+                );
+              }}
+            />
+            <TextField
+              isRequired
+              label="System Name"
+              type="string"
+              value={formData.name}
+              onChange={(e) => {
+                handleInputChange({ name: e });
+              }}
+            />
+          </Grid>
+          <Grid
+            container
+            size={6}
+          >
+            <CheckboxGroup
+              isRequired
+              value={selectedManureNames}
+              onChange={handleSelectedChange}
             >
-              <Select
-                isRequired
-                label="Manure Type"
-                selectedKey={formData.manureType}
-                items={MANURE_TYPE_OPTIONS}
-                onSelectionChange={(e: Key) => {
-                  handleInputChange({ manureType: e as number, manuresInSystem: [] });
-                  setFullManureList((prev) =>
-                    prev.map((m) => ({ ...m, data: { ...m.data, AssignedToStoredSystem: false } })),
-                  );
-                }}
-              />
-              <TextField
-                isRequired
-                label="System Name"
-                type="string"
-                value={formData.name}
-                onChange={(e) => {
-                  handleInputChange({ name: e });
-                }}
-              />
-            </Grid>
-            <Grid size={6}>
-              <CheckboxGroup
-                isRequired
-                value={selectedManureNames}
-                onChange={handleSelectedChange}
-              >
-                {availableManures.map((manure) => (
-                  <Checkbox
-                    key={manure.data.ManagedManureName}
-                    value={manure.data.ManagedManureName}
-                  >
-                    {manure.data.ManagedManureName}
-                  </Checkbox>
-                ))}
-              </CheckboxGroup>
-            </Grid>
+              {availableManures.map((manure) => (
+                <Checkbox
+                  key={manure.data.ManagedManureName}
+                  value={manure.data.ManagedManureName}
+                >
+                  {manure.data.ManagedManureName}
+                </Checkbox>
+              ))}
+            </CheckboxGroup>
           </Grid>
           <Grid
             container
             size={12}
-            direction="column"
           >
-            <Divider
-              aria-hidden="true"
-              component="div"
-              css={{ marginTop: '1rem', marginBottom: '1rem' }}
-            />
-            <Grid
-              container
-              size={12}
-              direction="row"
-            >
-              <Grid
-                container
-                size={5}
-                direction="row"
-              >
-                <TextField
-                  isRequired
-                  label="Storage Name"
-                  type="string"
-                  name="manureStorageStructures.Name"
-                  value={formData.manureStorageStructures.name}
-                  onChange={(e: any) => {
-                    handleStorageChange({ name: e });
-                  }}
-                />
-              </Grid>
-              <Grid
-                container
-                size={5}
-                direction="row"
-              >
-                <div
-                  style={{ marginBottom: '0.15rem' }}
-                  className="bcds-react-aria-Select--Label"
+            {formData.manureType === 1 && (
+              <>
+                <Grid
+                  container
+                  size={6}
                 >
-                  Is the storage covered?
                   <YesNoRadioButtons
-                    value={formData.manureStorageStructures.isStructureCovered}
-                    text=""
+                    value={formData.getsRunoffFromRoofsOrYards}
+                    text="Does yard or roof runoff enter the storage?"
                     onChange={(e: boolean) => {
-                      handleStorageChange({ isStructureCovered: e });
+                      handleInputChange({ getsRunoffFromRoofsOrYards: e });
                     }}
                     orientation="horizontal"
                   />
-                </div>
-                {!formData.manureStorageStructures.isStructureCovered && (
-                  <TextField
-                    isRequired
-                    label="Uncovered Area of Storage (ft2)"
-                    type="number"
-                    value={String(formData.manureStorageStructures.uncoveredAreaSqFt)}
-                    onChange={(e: string) => {
-                      handleStorageChange({ uncoveredAreaSqFt: Number(e) });
-                    }}
-                  />
+                </Grid>
+                {formData.getsRunoffFromRoofsOrYards === true && (
+                  <Grid
+                    container
+                    size={6}
+                  >
+                    <TextField
+                      isRequired
+                      label="Yard and Roof Area (ft2)"
+                      type="number"
+                      name="runoffAreaSqFt"
+                      value={String(formData.runoffAreaSqFt)}
+                      onChange={(e: string) => {
+                        handleInputChange({ runoffAreaSqFt: Number(e) });
+                      }}
+                    />
+                  </Grid>
                 )}
-              </Grid>
-            </Grid>
+              </>
+            )}
           </Grid>
         </Grid>
+        <Divider
+          aria-hidden="true"
+          component="div"
+          css={{ marginTop: '1rem', marginBottom: '1rem' }}
+        />
+
+        {formData.manureType === 1 && (
+          <Grid
+            container
+            size={formGridBreakpoints}
+            direction="row"
+            spacing={2}
+          >
+            <Grid
+              container
+              size={6}
+              direction="row"
+            >
+              <div
+                style={{ marginBottom: '0.15rem' }}
+                className="bcds-react-aria-Select--Label"
+              >
+                Is there solid/liquid separation?
+                <YesNoRadioButtons
+                  value={formData.IsThereSolidLiquidSeparation}
+                  text=""
+                  onChange={(e: boolean) => {
+                    handleInputChange({ IsThereSolidLiquidSeparation: e });
+                  }}
+                  orientation="horizontal"
+                />
+              </div>
+              {formData.IsThereSolidLiquidSeparation === true && (
+                <div style={{ display: 'flex', width: '100%' }}>
+                  <div style={{ paddingRight: '2em' }}>
+                    <TextField
+                      isRequired
+                      label="% of liquid volume separated"
+                      type="number"
+                      value={String(formData.PercentageOfLiquidVolumeSeparated)}
+                      onChange={(e: string) => {
+                        handleInputChange({ PercentageOfLiquidVolumeSeparated: Number(e) });
+                        const solidsSeparatedGallons = totalManureGallons * (Number(e) / 100);
+                        const separatedLiquidsGallons = totalManureGallons - solidsSeparatedGallons;
+                        const separatedSolidsTons = (solidsSeparatedGallons / 264.172) * 0.5;
+                        handleInputChange({
+                          SeparatedLiquidsUSGallons: Math.round(separatedLiquidsGallons),
+                          SeparatedSolidsTons: Math.round(separatedSolidsTons),
+                        });
+                      }}
+                    />
+                  </div>
+                </div>
+              )}
+            </Grid>
+            <Grid
+              container
+              size={6}
+              direction="row"
+            >
+              <div style={{ width: 'max-content', fontSize: '12px' }}>
+                <p>
+                  Separated liquids
+                  <p>{formData.SeparatedLiquidsUSGallons} U.S. Gallons</p>
+                </p>
+                <p>
+                  Separated solids
+                  <p>{formData.SeparatedSolidsTons} tons</p>
+                </p>
+              </div>
+            </Grid>
+          </Grid>
+        )}
+        <Divider
+          aria-hidden="true"
+          component="div"
+          css={{ marginTop: '1rem', marginBottom: '1rem' }}
+        />
+
+        <Grid
+          container
+          size={formGridBreakpoints}
+          direction="row"
+          spacing={2}
+        >
+          <Grid
+            container
+            size={6}
+            direction="row"
+          >
+            <TextField
+              isRequired
+              label="Storage Name"
+              type="string"
+              name="manureStorageStructures.Name"
+              value={formData.manureStorageStructures.name}
+              onChange={(e: any) => {
+                handleStorageChange({ name: e });
+              }}
+            />
+            <YesNoRadioButtons
+              value={formData.manureStorageStructures.isStructureCovered}
+              text="Is the storage covered?"
+              onChange={(e: boolean) => {
+                handleStorageChange({ isStructureCovered: e });
+              }}
+              orientation="horizontal"
+            />
+            {!formData.manureStorageStructures.isStructureCovered && formData.manureType === 2 && (
+              <TextField
+                isRequired
+                label="Uncovered Area of Storage (ft2)"
+                type="number"
+                value={String(formData.manureStorageStructures.uncoveredAreaSqFt)}
+                onChange={(e: string) => {
+                  handleStorageChange({ uncoveredAreaSqFt: Number(e) });
+                }}
+              />
+            )}
+            {formData.manureType === 1 && (
+              <Select
+                isRequired
+                label="Storage shape"
+                selectedKey={
+                  storageShapeOptions.find(
+                    (option) =>
+                      option.id === formData.manureStorageStructures.SelectedStorageStructureShape,
+                  )?.label
+                }
+                items={storageShapeOptions}
+                onSelectionChange={(e: any) => {
+                  // find storage shape by id
+                  const selectedShape = storageShapeOptions.find(
+                    (option) => option.id === e,
+                  )?.label;
+                  handleStorageChange({
+                    SelectedStorageStructureShape:
+                      selectedShape as ManureStorage['SelectedStorageStructureShape'],
+                  });
+                }}
+              />
+            )}
+          </Grid>
+          <Grid
+            container
+            size={6}
+            direction="row"
+          >
+            {formData.manureStorageStructures.SelectedStorageStructureShape === 'Circular' && (
+              <div>
+                <TextField
+                  isRequired
+                  label="Diameter(ft)"
+                  type="number"
+                  value={String(formData.manureStorageStructures.CircularDiameter)}
+                  onChange={(e: string) => {
+                    handleStorageChange({ CircularDiameter: Number(e) });
+                  }}
+                />
+                <TextField
+                  isRequired
+                  label="Height(ft)"
+                  type="number"
+                  value={String(formData.manureStorageStructures.CircularHeight)}
+                  onChange={(e: string) => {
+                    handleStorageChange({ CircularHeight: Number(e) });
+                  }}
+                />
+              </div>
+            )}
+            {formData.manureStorageStructures.SelectedStorageStructureShape === 'Rectangular' && (
+              <div>
+                <TextField
+                  isRequired
+                  label="Length(ft)"
+                  type="number"
+                  value={String(formData.manureStorageStructures.RectangularLength)}
+                  onChange={(e: string) => {
+                    handleStorageChange({ RectangularLength: Number(e) });
+                  }}
+                />
+                <TextField
+                  isRequired
+                  label="Width(ft)"
+                  type="number"
+                  value={String(formData.manureStorageStructures.RectangularWidth)}
+                  onChange={(e: string) => {
+                    handleStorageChange({ RectangularWidth: Number(e) });
+                  }}
+                />
+                <TextField
+                  isRequired
+                  label="Height(ft)"
+                  type="number"
+                  value={String(formData.manureStorageStructures.RectangularHeight)}
+                  onChange={(e: string) => {
+                    handleStorageChange({ RectangularHeight: Number(e) });
+                  }}
+                />
+              </div>
+            )}
+            {formData.manureStorageStructures.SelectedStorageStructureShape ===
+              'SlopedWallRectangular' && (
+              <div>
+                <TextField
+                  isRequired
+                  label="Diameter(ft)"
+                  type="number"
+                  value={String(formData.manureStorageStructures.CircularDiameter)}
+                  onChange={(e: string) => {
+                    handleStorageChange({ CircularDiameter: Number(e) });
+                  }}
+                />
+                <TextField
+                  isRequired
+                  label="Height(ft)"
+                  type="number"
+                  value={String(formData.manureStorageStructures.CircularHeight)}
+                  onChange={(e: string) => {
+                    handleStorageChange({ CircularHeight: Number(e) });
+                  }}
+                />
+                <TextField
+                  isRequired
+                  label="Diameter(ft)"
+                  type="number"
+                  value={String(formData.manureStorageStructures.CircularDiameter)}
+                  onChange={(e: string) => {
+                    handleStorageChange({ CircularDiameter: Number(e) });
+                  }}
+                />
+                <TextField
+                  isRequired
+                  label="Height(ft)"
+                  type="number"
+                  value={String(formData.manureStorageStructures.CircularHeight)}
+                  onChange={(e: string) => {
+                    handleStorageChange({ CircularHeight: Number(e) });
+                  }}
+                />
+              </div>
+            )}
+          </Grid>
+        </Grid>
+
         <Divider
           aria-hidden="true"
           component="div"


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [ ] Documentation is updated to reflect change

# Description
Added liquid storage fields for liquid manures, amended styling, re-enabled next button with unstored manures and added notification on reporting page of unstored manures.

This PR includes the following proposed change(s):

- Added fields applicable to liquid storage
- Added notification of unstored manures on reporting page and enabled next button
<img width="938" height="451" alt="Screenshot 2025-07-24 at 10 55 32 AM" src="https://github.com/user-attachments/assets/b09bfb2c-a46f-4780-9eb3-360119483d08" />
<img width="958" height="332" alt="Screenshot 2025-07-24 at 10 55 42 AM" src="https://github.com/user-attachments/assets/89a15e9f-6b65-4667-ab36-b9375ab3d402" />
<img width="758" height="799" alt="Screenshot 2025-07-24 at 10 56 00 AM" src="https://github.com/user-attachments/assets/a385598b-7f9c-428a-92bd-346015c1bf4a" />


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-nmp-391.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-nmp-391-backend.apps.silver.devops.gov.bc.ca/healthcheck/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/merge.yml)