### PR TITLE
feat(NMP-295): Add precip calc to manures (WIP DRAFT)

### DIFF
--- a/frontend/src/constants/PrecipitationConversionFactor.ts
+++ b/frontend/src/constants/PrecipitationConversionFactor.ts
@@ -1,0 +1,7 @@
+// eslint-disable-next-line no-shadow
+const enum PrecipitationConversionFactor {
+  liquid = 0.000102408,
+  solid = 0.024542388,
+}
+
+export default PrecipitationConversionFactor;

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -10,6 +10,7 @@ import { INITIAL_BEEF_FORM_DATA, INITIAL_DAIRY_FORM_DATA } from './Animals';
 import APP_STATE_KEY from './context';
 import { HarvestUnit, HARVEST_UNIT_OPTIONS } from './harvestUnits';
 import MANURE_TYPE_OPTIONS from './ManureTypeOptions';
+import PrecipitationConversionFactor from './PrecipitationConversionFactor';
 
 // TODO: Standardize these variable names. Global constants should be in all caps
 export {
@@ -28,4 +29,5 @@ export {
   HARVEST_UNIT_OPTIONS,
   MANURE_APPLICATION_FREQ,
   MANURE_TYPE_OPTIONS,
+  PrecipitationConversionFactor,
 };

--- a/frontend/src/types/NMPFileGeneratedManureData.ts
+++ b/frontend/src/types/NMPFileGeneratedManureData.ts
@@ -8,9 +8,10 @@ interface NMPFileGeneratedManureData {
   AnnualAmountTonsWeight?: number;
   AnnualAmountDisplayWeight?: string;
   ManagedManureName: string;
+  AnnualAmountOfManurePerStorage?: number;
   IsMaterialStored?: boolean;
   AssignedToStoredSystem?: boolean;
   AssignedWithNutrientAnalysis?: boolean;
-  manureId: string;
+  manureId?: string;
 }
 export default NMPFileGeneratedManureData;

--- a/frontend/src/types/NMPFileImportedManureData.ts
+++ b/frontend/src/types/NMPFileImportedManureData.ts
@@ -10,12 +10,14 @@ interface NMPFileImportedManureData {
   AnnualAmountTonsWeight?: number;
   AnnualAmountDisplayVolume?: string;
   AnnualAmountDisplayWeight?: string;
+  AnnualAmountOfManurePerStorage?: number;
   Units?: number;
   Moisture?: string;
   IsMaterialStored?: boolean;
   ManagedManureName: string;
   AssignedToStoredSystem?: boolean;
   AssignedWithNutrientAnalysis?: boolean;
+  manureId?: string;
 }
 
 export default NMPFileImportedManureData;

--- a/frontend/src/types/SubRegion.ts
+++ b/frontend/src/types/SubRegion.ts
@@ -1,0 +1,7 @@
+export default interface SubRegion {
+  id: number;
+  name: string;
+  annualprecipitation: number;
+  annualprecipitationocttomar: number;
+  regionid: number;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -15,6 +15,7 @@ import { NMPFileFieldData, NMPFileOtherNutrient } from './NMPFileFieldData';
 import NMPFileImportedManureData from './NMPFileImportedManureData';
 import SolidManureConversionFactors from './SolidManureConversionFactors';
 import Region from './Region';
+import SubRegion from './SubRegion';
 import Manure from './Manure';
 import {
   CalculateNutrientsColumn,
@@ -91,4 +92,5 @@ export type {
   FertilizerUnit,
   NMPFileOtherNutrient,
   ManureStorage,
+  SubRegion,
 };


### PR DESCRIPTION
## Pull Request Standards

- [ ] The title of the PR is accurate
- [ ] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [ ] The PR title includes the ticket number in format of `[NMP-###]`
- [ ] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Slight UI change
- Includes precipitation calcs for subregions that increase stored manure counts

TODO:
- Precip calculations inserted for manures when selected in the storage modal based on storage system/storages attributes (uncovered rainfall, etc) however if those attributes are modified after manures are selected, it does not update them properly.