### PR TITLE
fix(NMP-398): Fix Fertigation Feature Flag

### DIFF
--- a/frontend/src/views/CalculateNutrients/CalculateNutrients.tsx
+++ b/frontend/src/views/CalculateNutrients/CalculateNutrients.tsx
@@ -45,13 +45,9 @@ export default function CalculateNutrients() {
   const [activeField, setActiveField] = useState<number>(0);
   const [balanceMessages, setBalanceMessages] = useState<Array<NutrientMessage>>([]);
 
-  // shows fertigation if on localhost or openshift dev
-  const backendUrl = import.meta.env.VITE_BACKEND_URL;
-  const isDev =
-    backendUrl.includes('apps.silver.devops.gov.bc.ca') &&
-    !backendUrl.includes('test') &&
-    !backendUrl.includes('prod');
-  const enableFertigation = backendUrl.includes('localhost') || isDev;
+  // shows fertigation if on localhost
+  const backendUrl = import.meta.env.VITE_BACKEND_URL || '';
+  const enableFertigation = backendUrl.includes('localhost');
 
   const navigate = useNavigate();
 

--- a/frontend/src/views/CalculateNutrients/CalculateNutrients.tsx
+++ b/frontend/src/views/CalculateNutrients/CalculateNutrients.tsx
@@ -52,7 +52,6 @@ export default function CalculateNutrients() {
     !backendUrl.includes('test') &&
     !backendUrl.includes('prod');
   const enableFertigation = backendUrl.includes('localhost') || isDev;
-  console.log(enableFertigation);
 
   const navigate = useNavigate();
 

--- a/frontend/src/views/CalculateNutrients/CalculateNutrients.tsx
+++ b/frontend/src/views/CalculateNutrients/CalculateNutrients.tsx
@@ -45,9 +45,14 @@ export default function CalculateNutrients() {
   const [activeField, setActiveField] = useState<number>(0);
   const [balanceMessages, setBalanceMessages] = useState<Array<NutrientMessage>>([]);
 
-  // shows fertigation if on localhost
-  const backendUrl = import.meta.env.VITE_BACKEND_URL || '';
-  const enableFertigation = backendUrl.includes('localhost');
+  // shows fertigation if on localhost or openshift dev
+  const backendUrl = window?.config?.VITE_BACKEND_URL || import.meta.env.VITE_BACKEND_URL || '';
+  const isDev =
+    backendUrl.includes('apps.silver.devops.gov.bc.ca') &&
+    !backendUrl.includes('test') &&
+    !backendUrl.includes('prod');
+  const enableFertigation = backendUrl.includes('localhost') || isDev;
+  console.log(enableFertigation);
 
   const navigate = useNavigate();
 


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [ ] Documentation is updated to reflect change

# Description
- Correction to how we grab VITE_BACKEND_URL because OpenShift uses caddy web service to get env vars
- If local or OpenShift dev the fertigation button and modal are visible

This PR includes the following proposed change(s):

- Fix to backendUrl variable to properly get url when in OpenShift so the variable is not undefined which was having the page show as blank

(is fertigation not a real word? spellcheck doesn't like it)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-nmp-413.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-nmp-413-backend.apps.silver.devops.gov.bc.ca/healthcheck/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/merge.yml)