### PR TITLE
fix: Adjust selectable options for nutrient analysis entries

### DIFF
--- a/frontend/src/views/NutrientAnalysis/NutrientAnalysis.tsx
+++ b/frontend/src/views/NutrientAnalysis/NutrientAnalysis.tsx
@@ -59,8 +59,8 @@ export default function NutrientAnalysis() {
     setIsDialogOpen(true);
   };
 
-  const handleDelete = (name: string) => {
-    setNutrientAnalysisData((prevState) => prevState.filter((ele) => ele.materialSource !== name));
+  const handleDelete = (id: string) => {
+    setNutrientAnalysisData((prevState) => prevState.filter((ele) => ele.linkedUuid !== id));
   };
   const handleDialogClose = () => {
     setIsDialogOpen(false);
@@ -213,10 +213,16 @@ export default function NutrientAnalysis() {
         <NutrientAnalysisModal
           initialModalData={analysisForm}
           manures={manures.filter(
-            (manureEle) => !nutrientAnalysisData.some((ele) => ele.linkedUuid === manureEle.uuid),
+            (manureEle) =>
+              !nutrientAnalysisData.some(
+                (ele) => ele.linkedUuid === manureEle.uuid && editId !== manureEle.uuid,
+              ),
           )}
           storageSystems={storageSystems.filter(
-            (storeEle) => !nutrientAnalysisData.some((ele) => ele.linkedUuid === storeEle.uuid),
+            (storeEle) =>
+              !nutrientAnalysisData.some(
+                (ele) => ele.linkedUuid === storeEle.uuid && editId !== storeEle.uuid,
+              ),
           )}
           handleSubmit={handleModalSubmit}
           isOpen={isDialogOpen}


### PR DESCRIPTION
## Pull Request Standards

- [X] The title of the PR is accurate
- [X] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [ ] The PR title includes the ticket number in format of `[NMP-###]`
- [ ] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Adjust the list of manures (unstored and stored) such that when editing a manure, the manure being edited is not filtered out of the list of choosable manures.