### PR TITLE
fix: Moved leaf tissue inputs onto same line as requested

### DIFF
--- a/frontend/src/views/Crops/CropsModal.tsx
+++ b/frontend/src/views/Crops/CropsModal.tsx
@@ -654,8 +654,12 @@ function CropsModal({
                     />
                   </Grid>
                   {formData.hasLeafTest && (
-                    <>
-                      <Grid size={formGridBreakpoints}>
+                    <Grid
+                      container
+                      spacing={1}
+                      size={12}
+                    >
+                      <Grid size={6}>
                         <NumberField
                           isRequired={formData.hasLeafTest}
                           label="Leaf Tissue P (%)"
@@ -664,7 +668,7 @@ function CropsModal({
                           maxValue={100}
                         />
                       </Grid>
-                      <Grid size={formGridBreakpoints}>
+                      <Grid size={6}>
                         <NumberField
                           isRequired={formData.hasLeafTest}
                           label="Leaf Tissue K (%)"
@@ -673,7 +677,7 @@ function CropsModal({
                           maxValue={100}
                         />
                       </Grid>
-                    </>
+                    </Grid>
                   )}
                 </>
               )}


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Altered Grid component nesting to put leaf test inputs on the same line

<img width="685" height="786" alt="Screenshot 2025-09-02 at 9 37 29 AM" src="https://github.com/user-attachments/assets/04ece8d6-4f9d-4230-98a9-49bc5fd93d2e" />


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-nmp-449.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-nmp-449-backend.apps.silver.devops.gov.bc.ca/healthcheck/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/merge.yml)