### PR TITLE
fix: [NR-NMP-431] Change back/next buttons to position sticky at bottom of page.

### DIFF
--- a/frontend/src/common.styles.ts
+++ b/frontend/src/common.styles.ts
@@ -9,6 +9,7 @@ export const componentContainer = css({
   marginRight: '3rem',
   maxWidth: '900px',
   width: '100%',
+  minHeight: 'calc(100vh - 160px)',
 });
 
 export const formCss = css({
@@ -47,9 +48,7 @@ export const formCss = css({
 });
 
 export const hideCheckboxGroup = css({
-  height: '0',
-  overflow: 'hidden',
-  width: '0',
+  display: 'none',
 });
 
 export const showCheckboxGroup = css({
@@ -70,7 +69,7 @@ export const paragraphCss = css({
 
 export const buttonGroup = css({
   '.bcds-ButtonGroup': {
-    marginTop: '1rem',
+    flexGrow: '0',
   },
 });
 

--- a/frontend/src/components/common/Header/header.styles.ts
+++ b/frontend/src/components/common/Header/header.styles.ts
@@ -11,7 +11,7 @@ export const HeaderWrapper = styled.header`
   padding: 0;
   color: #fff;
   display: flex;
-  flex: 0 1 65px;
+  flex: 0 1 72px;
   justify-content: space-between;
   align-items: center;
   width: 100%;
@@ -36,6 +36,7 @@ export const Banner = styled.div`
   display: flex;
   align-items: center;
   margin: 0;
+  height: 72px;
 `;
 
 export const BannerRight = styled.div`

--- a/frontend/src/components/common/View/View.tsx
+++ b/frontend/src/components/common/View/View.tsx
@@ -8,9 +8,18 @@ interface ViewProps {
   children: React.ReactNode;
   handleBack?: () => void;
   handleNext?: () => void;
+  backBtnText?: string;
+  nextBtnText?: string;
 }
 
-export default function View({ title, children, handleBack, handleNext }: ViewProps) {
+export default function View({
+  title,
+  children,
+  handleBack,
+  handleNext,
+  backBtnText = 'Back',
+  nextBtnText = 'Next',
+}: ViewProps) {
   return (
     <StyledContent>
       <ProgressStepper />
@@ -30,7 +39,7 @@ export default function View({ title, children, handleBack, handleNext }: ViewPr
                 onPress={handleBack}
                 variant="secondary"
               >
-                Back
+                {backBtnText}
               </Button>
             )}
             {handleNext && (
@@ -39,7 +48,7 @@ export default function View({ title, children, handleBack, handleNext }: ViewPr
                 onPress={handleNext}
                 variant="primary"
               >
-                Next
+                {nextBtnText}
               </Button>
             )}
           </ButtonGroup>

--- a/frontend/src/components/common/View/view.style.ts
+++ b/frontend/src/components/common/View/view.style.ts
@@ -2,13 +2,14 @@
  * @summary Styling for AddAnimals view
  */
 import styled from '@emotion/styled';
-import { componentContainer, paragraphCss } from '../../../common.styles';
+import { buttonGroup, componentContainer, paragraphCss } from '../../../common.styles';
 
 export const StyledContent = styled.div`
   margin-bottom: 1rem;
 
   ${componentContainer}
   ${paragraphCss}
+  ${buttonGroup}
 `;
 
 export const AppTitleStyle = styled.div`
@@ -40,4 +41,5 @@ export const ButtonGroupWrapper = styled.div`
   background-color: white;
   padding-top: 1rem;
   padding-bottom: 1rem;
+  margin-top: auto;
 `;

--- a/frontend/src/views/FarmInformation/FarmInformation.tsx
+++ b/frontend/src/views/FarmInformation/FarmInformation.tsx
@@ -1,11 +1,9 @@
 /**
  * @summary The Farm Information page for the application
  */
-import React, { useState, useEffect, useContext, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useContext, useMemo, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
-  Button,
-  ButtonGroup,
   Checkbox,
   CheckboxGroup,
   // This is the one file where Form needs to be imported from the BC DS
@@ -30,6 +28,7 @@ export default function FarmInformation() {
   const { state, dispatch } = useAppState();
   const navigate = useNavigate();
   const apiCache = useContext(APICacheContext);
+  const formRef = useRef<null | HTMLFormElement>(null);
 
   // Initialize non-bool values to prevent errors on first render
   const [formData, setFormData] = useState<NMPFileFarmDetails>({
@@ -169,15 +168,22 @@ export default function FarmInformation() {
     }
   };
 
-  const handlePeviousPage = () => {
+  const handlePreviousPage = () => {
     navigate(LANDING_PAGE);
   };
 
   return (
-    <View title="Farm Information">
+    <View
+      title="Farm Information"
+      handleBack={handlePreviousPage}
+      // Trigger submit event to use <Form>'s validation
+      handleNext={() => formRef.current?.requestSubmit()}
+    >
       <Form
         css={formCss}
         onSubmit={onSubmit}
+        // @ts-ignore
+        ref={formRef}
       >
         <Grid
           container
@@ -265,27 +271,6 @@ export default function FarmInformation() {
             </CheckboxGroup>
           </Grid>
         </Grid>
-
-        <ButtonGroup
-          alignment="start"
-          ariaLabel="A group of buttons"
-          orientation="horizontal"
-        >
-          <Button
-            size="medium"
-            onPress={handlePeviousPage}
-            variant="secondary"
-          >
-            Back
-          </Button>
-          <Button
-            size="medium"
-            variant="primary"
-            type="submit"
-          >
-            Next
-          </Button>
-        </ButtonGroup>
       </Form>
     </View>
   );

--- a/frontend/src/views/Reporting/Reporting.tsx
+++ b/frontend/src/views/Reporting/Reporting.tsx
@@ -117,8 +117,19 @@ export default function FieldList() {
     navigate(CALCULATE_NUTRIENTS);
   };
 
+  const handleNextPage = () => {
+    window.location.href =
+      'https://www2.gov.bc.ca/gov/content/industry/agriculture-seafood/agricultural-land-and-' +
+      'environment/soil-nutrients/nutrient-management/what-to-apply/soil-nutrient-testing';
+  };
+
   return (
-    <View title="Reporting">
+    <View
+      title="Reporting"
+      handleBack={handlePreviousPage}
+      handleNext={handleNextPage}
+      nextBtnText="Finish"
+    >
       {/* only show if you have dairy cattle */}
       {unassignedManures.length > 0 && isDairyCattle && (
         <Grid
@@ -178,32 +189,6 @@ export default function FieldList() {
           </div>
         </Grid>
       </Grid>
-      <ButtonGroup
-        alignment="start"
-        ariaLabel="A group of buttons"
-        orientation="horizontal"
-      >
-        <Button
-          size="medium"
-          variant="secondary"
-          onPress={handlePreviousPage}
-        >
-          Back
-        </Button>
-        {/* Go to BC soil nutrient testing site */}
-        <Button
-          size="medium"
-          variant="primary"
-          onPress={() => {
-            navigate(
-              'https://www2.gov.bc.ca/gov/content/industry/agriculture-seafood/agricultural-land-and-' +
-                'environment/soil-nutrients/nutrient-management/what-to-apply/soil-nutrient-testing',
-            );
-          }}
-        >
-          Finished
-        </Button>
-      </ButtonGroup>
       <div style={{ height: '0px', overflow: 'hidden' }}>
         <div ref={reportRef}>
           <CompleteReportTemplate />


### PR DESCRIPTION
## Pull Request Standards

- [X] The title of the PR is accurate
- [X] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [X] The PR title includes the ticket number in format of `[NMP-###]`
- [ ] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Adjust CSS of back/next buttons to a sticky footer

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-nmp-451.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-nmp-451-backend.apps.silver.devops.gov.bc.ca/healthcheck/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/merge.yml)