### PR TITLE
fix: [NR-NMP-407] Fix forage crop and cover crop nutrient calculation in Add Crops modal

### DIFF
--- a/frontend/src/calculations/FieldAndSoil/Crops/Calculations.ts
+++ b/frontend/src/calculations/FieldAndSoil/Crops/Calculations.ts
@@ -91,14 +91,13 @@ export async function getCropSoilTestRegions(
  */
 export async function getKelownaRangeByPpm(STP: number, endpoint: string) {
   try {
-    // console.log('ini', STP, endpoint)
     const ranges = await axios.get(`${env.VITE_BACKEND_URL}/api/${endpoint}/`);
-    // console.log('ranges', ranges.data)
-
+    // Kelowna ranges have a 1 integer gap between.
+    // Just the right soil test may fail to fall into a range.
+    const roundedSTP = Math.round(STP);
     const response = ranges.data.find(
-      (range: any) => range.rangelow <= STP && range.rangehigh >= STP,
+      (range: any) => range.rangelow <= roundedSTP && range.rangehigh >= roundedSTP,
     );
-    // console.log('response', response)
 
     return response;
   } catch (error) {

--- a/frontend/src/views/SoilTests/SoilTestsModal.tsx
+++ b/frontend/src/views/SoilTests/SoilTestsModal.tsx
@@ -60,18 +60,22 @@ export default function SoilTestsModal({
           soilTestMethods.find((method) => method.id === soilTestId)!.value.converttokelownak
         : formData.valK!;
 
-    setFormData((prev) => ({
-      ...prev,
-      convertedKelownaP,
-      convertedKelownaK,
-    }));
+    setFormData((prevFormData) => {
+      const newFormData = {
+        ...prevFormData,
+        convertedKelownaP,
+        convertedKelownaK,
+      };
 
-    setFields((prev) => {
-      const newList = [...prev];
-      if (currentFieldIndex !== null)
-        newList[currentFieldIndex].SoilTest = { ...formData, soilTestId };
-      return newList;
+      setFields((prevFields) => {
+        const newList = [...prevFields];
+        if (currentFieldIndex !== null)
+          newList[currentFieldIndex].SoilTest = { ...newFormData, soilTestId };
+        return newList;
+      });
+      return newFormData;
     });
+
     handleDialogClose();
   };
 


### PR DESCRIPTION
## Pull Request Standards

- [X] The title of the PR is accurate
- [X] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [X] The PR title includes the ticket number in format of `[NMP-###]`
- [ ] Documentation is updated to reflect change

# Description
Two calculation bugs in Add Crops modal:
- Forage crop types had incorrect K and P numbers when a soil test was added.
- Cover crop types had incorrect N numbers when cover crop was not harvested.
- getKelownaRangeByPpm occasionally fails to find Kelowna range due to gaps in data.

This PR includes the following proposed change(s):

- Fixed soil test modal not adding all values properly, causing Add Crop calculations to calculate incorrectly.
- Added check for cover crops in N crop removal calculations.
- Fixed getKelownaRangeByPpm through rounding

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-nmp-452.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-nmp-452-backend.apps.silver.devops.gov.bc.ca/healthcheck/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-nmp-452.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-nmp-452-backend.apps.silver.devops.gov.bc.ca/healthcheck/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/merge.yml)