### PR TITLE
fix: [NR-NMP-473] Nutrient Analysis Defaults to Lab when Other Manure Selected

### DIFF
--- a/frontend/src/views/NutrientAnalysis/NutrientAnalysisModal.tsx
+++ b/frontend/src/views/NutrientAnalysis/NutrientAnalysisModal.tsx
@@ -206,7 +206,10 @@ export default function NutrientAnalysisModal({
                 const opt = manureOptions.find((r) => r.id === e)!;
                 handleInputChanges({
                   manureName: e as string,
-                  bookLab: 'book',
+                  bookLab:
+                    (e as string) === '(Other, solid)' || (e as string) === '(Other, liquid)'
+                      ? 'lab'
+                      : 'book',
                   nMineralizationId: opt.value.nmineralizationid,
                 });
               }}
@@ -216,7 +219,11 @@ export default function NutrientAnalysisModal({
           <Grid size={formGridBreakpoints}>
             <Checkbox
               isRequired={!formData.bookLab}
-              isDisabled={!(formData.sourceUuid && formData.manureId)}
+              isDisabled={
+                !(formData.sourceUuid && formData.manureId) ||
+                formData.manureName === '(Other, solid)' ||
+                formData.manureName === '(Other, liquid)'
+              }
               value="book"
               isSelected={formData.bookLab === 'book'}
               onChange={(s: boolean) => handleInputChanges({ bookLab: s ? 'book' : '' })}


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [ ] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Book button disabled when manure name is Other solid or liquid
- formData.bookLab === 'lab' when manure name is other solid or liquid
<img width="728" height="574" alt="Screenshot 2025-10-28 at 3 19 46 PM" src="https://github.com/user-attachments/assets/27d18ece-0024-4496-96aa-8ea5cd99a0fd" />

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-nmp-510.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-nmp-510-backend.apps.silver.devops.gov.bc.ca/healthcheck/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/merge.yml)