### PR TITLE
fix: [NR-NMP-564] Hide message when manure type is undefined

### DIFF
--- a/frontend/src/views/Storage/StorageSystemDetailsEdit.tsx
+++ b/frontend/src/views/Storage/StorageSystemDetailsEdit.tsx
@@ -218,7 +218,7 @@ export default function StorageSystemDetailsEdit({
           container
           size={6}
         >
-          {availableManures.length > 0 ? (
+          {formData.manureType === undefined || availableManures.length > 0 ? (
             <CheckboxGroup
               aria-label="Manures in System"
               isRequired
@@ -235,7 +235,7 @@ export default function StorageSystemDetailsEdit({
               ))}
             </CheckboxGroup>
           ) : (
-            <span>
+            <span style={{ font: 'var(--typography-regular-small-body)' }}>
               There are no unstored materials of this type. To add materials, please return to Add
               Animals or Manure and Imports.
             </span>


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Added formatting to "no unstored manure message"
- Message is hidden when formData.manureType is undefined

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-nmp-568.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-nmp-568-backend.apps.silver.devops.gov.bc.ca/healthcheck/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/merge.yml)