### PR TITLE
fix: update page title from 'Field Information' to 'Soil Tests' in SoilTests view (#624)

### DIFF
--- a/frontend/src/views/SoilTests/SoilTests.tsx
+++ b/frontend/src/views/SoilTests/SoilTests.tsx
@@ -264,7 +264,7 @@ export default function SoilTests() {
   );
   return (
     <View
-      title="Field Information"
+      title="Soil Tests"
       handleBack={handlePreviousPage}
       handleNext={handleNextPage}
     >


### PR DESCRIPTION
Updated the page title in SoilTests.tsx from 'Field Information' to 'Soil Tests' to correctly identify the subpage of the Fields and Soil page.

Fixes #624