### PR TITLE
fix: [NR-NMP-663] Dairy field defaults behavior

### DIFF
--- a/frontend/src/views/AddAnimals/AnimalFormComponents/MilkingFields.tsx
+++ b/frontend/src/views/AddAnimals/AnimalFormComponents/MilkingFields.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Grid from '@mui/material/Grid';
+import LoopIcon from '@mui/icons-material/Loop';
 import { WashWaterUnit } from '@/types';
 import { NumberField, Select } from '@/components/common';
 import { formGridBreakpoints } from '@/common.styles';
@@ -34,12 +35,20 @@ export default function MilkingFields({
   const [milkProduction, setMilkProduction] = useState<number>(milkProductionInit);
   const [washWater, setWashWater] = useState<number>(washWaterInit);
 
+  const washWaterDefaultCorrected = useMemo(
+    () =>
+      washWaterUnit === PER_DAY_PER_ANIMAL_UNIT
+        ? washWaterDefault
+        : washWaterDefault * animalsPerFarm,
+    [washWaterUnit, animalsPerFarm, washWaterDefault],
+  );
+
   // When the breed changes, change the milk production value
   useEffect(() => {
-    setMilkProduction(milkProductionInit);
-    handleInputChanges({ milkProduction: milkProductionInit });
+    setMilkProduction(milkProductionDefault);
+    handleInputChanges({ milkProduction: milkProductionDefault, milkProductionAdjusted: false });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [milkProductionInit]);
+  }, [milkProductionDefault]);
 
   // On mount, set milking fields to init values
   // On unmount, clear milking fields
@@ -50,7 +59,7 @@ export default function MilkingFields({
       washWater: washWaterInit,
       // Per day per animal is the default
       washWaterUnit: washWaterUnit || PER_DAY_PER_ANIMAL_UNIT,
-      washWaterAdjusted: washWaterDefault !== washWaterInit,
+      washWaterAdjusted: washWaterDefaultCorrected !== washWaterInit,
     });
     return () => {
       handleInputChanges({
@@ -66,11 +75,19 @@ export default function MilkingFields({
 
   const handleUnitChange = (newUnit: WashWaterUnit) => {
     if (newUnit === PER_DAY_PER_ANIMAL_UNIT && washWaterUnit === PER_DAY_UNIT) {
-      setWashWater(washWaterInit);
-      handleInputChanges({ washWater: washWaterInit, washWaterUnit: newUnit });
+      setWashWater(washWaterDefault);
+      handleInputChanges({
+        washWater: washWaterDefault,
+        washWaterUnit: newUnit,
+        washWaterAdjusted: false,
+      });
     } else if (newUnit === PER_DAY_UNIT && washWaterUnit === PER_DAY_PER_ANIMAL_UNIT) {
-      setWashWater(washWaterInit * animalsPerFarm);
-      handleInputChanges({ washWater: washWaterInit * animalsPerFarm, washWaterUnit: newUnit });
+      setWashWater(washWaterDefault * animalsPerFarm);
+      handleInputChanges({
+        washWater: washWaterDefault * animalsPerFarm,
+        washWaterUnit: newUnit,
+        washWaterAdjusted: false,
+      });
     } else {
       handleInputChanges({ washWaterUnit: newUnit });
     }
@@ -90,6 +107,23 @@ export default function MilkingFields({
               milkProductionAdjusted: milkProductionDefault !== e,
             });
           }}
+          iconRight={
+            milkProduction !== milkProductionDefault ? (
+              <button
+                type="button"
+                css={{ backgroundColor: '#ffa500' }}
+                onClick={() => {
+                  setMilkProduction(milkProductionDefault);
+                  handleInputChanges({
+                    milkProduction: milkProductionDefault,
+                    milkProductionAdjusted: false,
+                  });
+                }}
+              >
+                <LoopIcon />
+              </button>
+            ) : undefined
+          }
         />
       </Grid>
       <Grid size={formGridBreakpoints}>
@@ -99,8 +133,28 @@ export default function MilkingFields({
           value={washWater}
           onChange={(e) => {
             setWashWater(e);
-            handleInputChanges({ washWater: e, washWaterAdjusted: washWaterDefault !== e });
+            handleInputChanges({
+              washWater: e,
+              washWaterAdjusted: washWaterDefaultCorrected !== e,
+            });
           }}
+          iconRight={
+            washWater !== washWaterDefaultCorrected ? (
+              <button
+                type="button"
+                css={{ backgroundColor: '#ffa500' }}
+                onClick={() => {
+                  setWashWater(washWaterDefaultCorrected);
+                  handleInputChanges({
+                    washWater: washWaterDefaultCorrected,
+                    washWaterAdjusted: false,
+                  });
+                }}
+              >
+                <LoopIcon />
+              </button>
+            ) : undefined
+          }
         />
       </Grid>
       <Grid size={formGridBreakpoints}>


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Added default reset button to milk production and wash water
- Corrected the wash water default (previously it didn't take the unit into account)
- Made the behavior of changing wash water units match old NMP (instead of keeping the wash water amount input by the user, it resets to the default)
- Corrected the milk production behavior when changing breed (previously, if the user had edited or saved the milk production, it wouldn't change to the breed default)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-nmp-643.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-nmp-643-backend.apps.silver.devops.gov.bc.ca/healthcheck/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/merge.yml)