### PR TITLE
fix: [NR-NMP-618] Show optional fertilizer fields in report

### DIFF
--- a/frontend/src/views/CalculateNutrients/CalculateNutrientsComponents/FertilizerModal.tsx
+++ b/frontend/src/views/CalculateNutrients/CalculateNutrientsComponents/FertilizerModal.tsx
@@ -598,7 +598,7 @@ export default function FertilizerModal({
           <Grid size={formGridBreakpoints}>
             <InputField
               label="Date"
-              type="date"
+              type="month"
               name="applDate"
               value={formState.applDate || ''}
               onChange={(e: any) => {

--- a/frontend/src/views/Reporting/makeFullReport.ts
+++ b/frontend/src/views/Reporting/makeFullReport.ts
@@ -140,7 +140,8 @@ const generateApplicationSchedule = (
               ? SEASON_APPLICATION.find(
                 (s) => s.Id === nutrientSource.applicationId,
               )!.Season
-              : '',
+              // Fertilizers may have an application date
+              : nutrientSource.applDate || '',
             // Example display: 10 L/ac
             `${nutrientSource.applicationRate} ${fertilizerUnits.find((f) => f.id === nutrientSource.applUnitId)!.name}`,
           ])
@@ -662,10 +663,9 @@ const generateFieldSummary = (
     body:
       allApplied.length > 0
         ? allApplied.map((nutrientSource) => {
-          let seasonApplication;
-          // Manures, but not fertilizers, have a season and application method
           if ('applicationId' in nutrientSource) {
-            seasonApplication = SEASON_APPLICATION.find(
+            // Manures have 'applicationId' and seasonal values
+            const seasonApplication = SEASON_APPLICATION.find(
               (s) => s.Id === nutrientSource.applicationId,
             );
             if (!seasonApplication) {
@@ -673,11 +673,19 @@ const generateFieldSummary = (
                 `Season application ${nutrientSource.applicationId} not found`,
               );
             }
+            return [
+              nutrientSource.name,
+              seasonApplication.Season,
+              seasonApplication.ApplicationMethod,
+              // Example display: 10 L/ac
+              `${nutrientSource.applicationRate} ${fertilizerUnits.find((f) => f.id === nutrientSource.applUnitId)!.name}`,
+            ];
           }
+          // Fertilizers have different properties
           return [
             nutrientSource.name,
-            seasonApplication?.Season || '',
-            seasonApplication?.ApplicationMethod || '',
+            nutrientSource.applDate || '',
+            nutrientSource.applicationMethod || '',
             // Example display: 10 L/ac
             `${nutrientSource.applicationRate} ${fertilizerUnits.find((f) => f.id === nutrientSource.applUnitId)!.name}`,
           ];


### PR DESCRIPTION
## Pull Request Standards

- [ ] The title of the PR is accurate
- [ ] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [ ] The PR title includes the ticket number in format of `[NMP-###]`
- [ ] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Added fertilizer properties to the report, as the ticket originally stated
- Changed the fertilizer input to a month input

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-nmp-669.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-nmp-669-backend.apps.silver.devops.gov.bc.ca/healthcheck/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/merge.yml)