### PR TITLE
feat: [NR-NMP-621] Field tabs on Calculate Nutrients made clickable

### DIFF
--- a/frontend/src/components/common/Tabs/Tabs.tsx
+++ b/frontend/src/components/common/Tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import MUITabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Box from '@mui/material/Box';
@@ -6,9 +6,11 @@ import Box from '@mui/material/Box';
 export default function Tabs({
   activeTab,
   tabLabel,
+  onChange,
 }: {
   activeTab: number;
   tabLabel: Array<string>;
+  onChange?: ((event: React.SyntheticEvent, value: any) => void) | undefined;
 }) {
   const [value, setValue] = useState(activeTab);
 
@@ -20,6 +22,7 @@ export default function Tabs({
         <MUITabs
           value={value}
           aria-label="tab"
+          onChange={onChange}
         >
           {tabLabel.map((ele, i) => (
             <Tab

--- a/frontend/src/views/CalculateNutrients/CalculateNutrients.tsx
+++ b/frontend/src/views/CalculateNutrients/CalculateNutrients.tsx
@@ -390,6 +390,7 @@ export default function CalculateNutrients() {
             ? fieldList.map((field) => field.fieldName)
             : ['Field 1']
         }
+        onChange={(_, f) => setActiveField(f)}
       />
       <ButtonGroup
         alignment="end"


### PR DESCRIPTION
## Pull Request Standards

- [ ] The title of the PR is accurate
- [ ] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [ ] The PR title includes the ticket number in format of `[NMP-###]`
- [ ] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Added the MaterialUI Tabs "onChange" property to our wrapper class
- Added simple onChange func to field tabs, using https://mui.com/material-ui/react-tabs/ as reference

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-nmp-671.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-nmp-671-backend.apps.silver.devops.gov.bc.ca/healthcheck/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/merge.yml)