### PR TITLE
fix: [NR-NMP-638] Display amount prop based on type

### DIFF
--- a/frontend/src/views/Reporting/makeFullReport.ts
+++ b/frontend/src/views/Reporting/makeFullReport.ts
@@ -279,7 +279,7 @@ const generateManureCompostInventory = (
             : [];
           newRows.push([
             `        ${manure.uniqueMaterialName}`,
-            `${printNum(manure.annualAmount)} ${manure.manureType === ManureType.Liquid ? 'US gallons' : 'tons'}`,
+            `${printNum(manure.manureType === ManureType.Liquid ? manure.annualAmountUSGallonsVolume! : manure.annualAmountTonsWeight!)} ${manure.manureType === ManureType.Liquid ? 'US gallons' : 'tons'}`,
           ]);
           return acc.concat(newRows);
         }, [] as RowInput[]),


### PR DESCRIPTION
## Pull Request Standards

- [ ] The title of the PR is accurate
- [ ] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [ ] The PR title includes the ticket number in format of `[NMP-###]`
- [ ] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Since users can input values that are different than the units we display (and the user's inputted value is always stored in annualAmount) use properties that correspond to the report unit

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-nmp-672.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-nmp-672-backend.apps.silver.devops.gov.bc.ca/healthcheck/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/merge.yml)