### PR TITLE
fix: [NR-NMP-635] Display previous crop name instead of n credit

### DIFF
--- a/frontend/src/views/Reporting/Reporting.tsx
+++ b/frontend/src/views/Reporting/Reporting.tsx
@@ -22,6 +22,7 @@ import {
   LiquidMaterialApplicationUsGallonsPerAcreRateConversions,
   MaterialRemainingData,
   Subregion,
+  PreviousCrop,
 } from '@/types';
 import { DAIRY_COW_ID } from '@/constants';
 import makeFullReportPdf from './makeFullReport';
@@ -48,6 +49,7 @@ export default function Reporting() {
     LiquidMaterialApplicationUsGallonsPerAcreRateConversions[]
   >([]);
   const manures: Manure[] = apiCache.getInitializedResponse('manures').data;
+  const [previousCrops, setPreviousCrops] = useState<PreviousCrop[]>([]);
   const [materialRemainingData, setMaterialRemainingData] = useState<MaterialRemainingData | null>(null);
 
   const unassignedManures = useMemo(
@@ -120,6 +122,13 @@ export default function Reporting() {
           }
         },
       );
+    apiCache
+      .callEndpoint('api/previouscroptypes/')
+      .then((response: { status?: any; data: PreviousCrop[] }) => {
+        if (response.status === 200) {
+          setPreviousCrops(response.data);
+        }
+      });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -242,6 +251,7 @@ export default function Reporting() {
                   soilTestMethods,
                   phosphorousRanges,
                   potassiumRanges,
+                  previousCrops,
                   materialRemainingData,
                 )}
               >

--- a/frontend/src/views/Reporting/makeFullReport.ts
+++ b/frontend/src/views/Reporting/makeFullReport.ts
@@ -23,6 +23,7 @@ import {
   SoilTestNutrientRange,
   MaterialRemainingData,
   Subregion,
+  PreviousCrop,
 } from '@/types';
 import SEASON_APPLICATION from '../CalculateNutrients/unseededData';
 import {
@@ -555,6 +556,7 @@ const generateFieldSummary = (
   soilTestMethods: SoilTestMethods[],
   phosphorousRanges: SoilTestNutrientRange[],
   potassiumRanges: SoilTestNutrientRange[],
+  previousCrops: PreviousCrop[],
 ) => {
   doc.addPage();
   // First table shows crops
@@ -581,7 +583,7 @@ const generateFieldSummary = (
     body: field.crops.map((crop) => [
       `${crop.name}`,
       `${crop.yield} ${crop.yieldHarvestUnit ? crop.yieldHarvestUnit : 'ton/ac'}`,
-      `${crop.nCredit === 0 ? 'none (no N credit)' : crop.nCredit}`,
+      `${previousCrops.find((c) => c.id === crop.prevCropId)?.name || 'none (no N credit)'}`,
     ]),
   });
 
@@ -1070,6 +1072,7 @@ export default async function makeFullReportPdf(
   soilTestMethods: SoilTestMethods[],
   phosphorousRanges: SoilTestNutrientRange[],
   potassiumRanges: SoilTestNutrientRange[],
+  previousCrops: PreviousCrop[],
   materialRemainingData: MaterialRemainingData | null,
 ) {
   // eslint-disable-next-line new-cap
@@ -1153,6 +1156,7 @@ export default async function makeFullReportPdf(
       soilTestMethods,
       phosphorousRanges,
       potassiumRanges,
+      previousCrops,
     );
   }
 


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NMP-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Fetch previous crop table on report page
- Use that data to display the name that corresponds with the id or "none (no N credit)"

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-nmp-673.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-nmp-673-backend.apps.silver.devops.gov.bc.ca/healthcheck/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-nmp/actions/workflows/merge.yml)